### PR TITLE
feat(crypto): add BLS types and integrate blst crate (#18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "blst"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +534,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1363,7 +1387,10 @@ name = "rvc"
 version = "0.1.0"
 dependencies = [
  "beacon-client",
+ "blst",
+ "hex",
  "prost",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
@@ -1601,6 +1628,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -2282,6 +2318,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ tonic = "0.12"
 prost = "0.13"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
+# Crypto
+blst = "0.3"
+hex = "0.4"
+rand = "0.8"
+
 # Dev dependencies
 wiremock = "0.6"
 

--- a/crates/rvc/Cargo.toml
+++ b/crates/rvc/Cargo.toml
@@ -16,6 +16,9 @@ tracing.workspace = true
 tonic.workspace = true
 prost.workspace = true
 reqwest.workspace = true
+blst.workspace = true
+hex.workspace = true
+rand.workspace = true
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/crates/rvc/src/crypto/bls.rs
+++ b/crates/rvc/src/crypto/bls.rs
@@ -1,0 +1,286 @@
+use std::fmt;
+
+use blst::min_pk::{
+    AggregateSignature, PublicKey as BlstPublicKey, SecretKey as BlstSecretKey,
+    Signature as BlstSignature,
+};
+use blst::BLST_ERROR;
+use rand::RngCore;
+
+use super::error::BlsError;
+
+const DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
+
+pub const PUBLIC_KEY_BYTES_LEN: usize = 48;
+pub const SECRET_KEY_BYTES_LEN: usize = 32;
+pub const SIGNATURE_BYTES_LEN: usize = 96;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct PublicKey(BlstPublicKey);
+
+impl PublicKey {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, BlsError> {
+        BlstPublicKey::from_bytes(bytes)
+            .map(PublicKey)
+            .map_err(|e| BlsError::InvalidPublicKey(format!("{:?}", e)))
+    }
+
+    pub fn to_bytes(&self) -> [u8; PUBLIC_KEY_BYTES_LEN] {
+        self.0.to_bytes()
+    }
+}
+
+impl fmt::Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "0x{}", hex::encode(self.to_bytes()))
+    }
+}
+
+impl fmt::Debug for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PublicKey({})", self)
+    }
+}
+
+#[derive(Clone)]
+pub struct SecretKey(BlstSecretKey);
+
+impl SecretKey {
+    pub fn generate() -> Self {
+        let mut ikm = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut ikm);
+        SecretKey(
+            BlstSecretKey::key_gen(&ikm, &[])
+                .expect("key generation should not fail with valid IKM"),
+        )
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, BlsError> {
+        BlstSecretKey::from_bytes(bytes)
+            .map(SecretKey)
+            .map_err(|e| BlsError::InvalidSecretKey(format!("{:?}", e)))
+    }
+
+    pub fn to_bytes(&self) -> [u8; SECRET_KEY_BYTES_LEN] {
+        self.0.to_bytes()
+    }
+
+    pub fn public_key(&self) -> PublicKey {
+        PublicKey(self.0.sk_to_pk())
+    }
+
+    pub fn sign(&self, message: &[u8]) -> Signature {
+        Signature(self.0.sign(message, DST, &[]))
+    }
+}
+
+impl fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SecretKey([REDACTED])")
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct Signature(BlstSignature);
+
+impl Signature {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, BlsError> {
+        BlstSignature::from_bytes(bytes)
+            .map(Signature)
+            .map_err(|e| BlsError::InvalidSignature(format!("{:?}", e)))
+    }
+
+    pub fn to_bytes(&self) -> [u8; SIGNATURE_BYTES_LEN] {
+        self.0.to_bytes()
+    }
+
+    pub fn verify(&self, public_key: &PublicKey, message: &[u8]) -> Result<(), BlsError> {
+        let result = self.0.verify(true, message, DST, &[], &public_key.0, true);
+        if result == BLST_ERROR::BLST_SUCCESS {
+            Ok(())
+        } else {
+            Err(BlsError::SignatureVerificationFailed)
+        }
+    }
+
+    pub fn aggregate(signatures: &[&Signature]) -> Result<Self, BlsError> {
+        if signatures.is_empty() {
+            return Err(BlsError::InvalidSignature("cannot aggregate empty list".to_string()));
+        }
+
+        let blst_sigs: Vec<&BlstSignature> = signatures.iter().map(|s| &s.0).collect();
+        let agg = AggregateSignature::aggregate(&blst_sigs, true)
+            .map_err(|e| BlsError::InvalidSignature(format!("{:?}", e)))?;
+
+        Ok(Signature(agg.to_signature()))
+    }
+
+    pub fn verify_aggregate(
+        &self,
+        public_keys: &[&PublicKey],
+        message: &[u8],
+    ) -> Result<(), BlsError> {
+        if public_keys.is_empty() {
+            return Err(BlsError::InvalidPublicKey(
+                "cannot verify with empty public key list".to_string(),
+            ));
+        }
+
+        let blst_pks: Vec<&BlstPublicKey> = public_keys.iter().map(|pk| &pk.0).collect();
+        let msgs: Vec<&[u8]> = vec![message; public_keys.len()];
+
+        let result = self.0.aggregate_verify(true, &msgs, DST, &blst_pks, true);
+        if result == BLST_ERROR::BLST_SUCCESS {
+            Ok(())
+        } else {
+            Err(BlsError::SignatureVerificationFailed)
+        }
+    }
+}
+
+impl fmt::Display for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "0x{}", hex::encode(self.to_bytes()))
+    }
+}
+
+impl fmt::Debug for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Signature({})", self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_secret_key_generation() {
+        let sk1 = SecretKey::generate();
+        let sk2 = SecretKey::generate();
+        assert_ne!(sk1.to_bytes(), sk2.to_bytes());
+    }
+
+    #[test]
+    fn test_secret_key_bytes_roundtrip() {
+        let sk = SecretKey::generate();
+        let bytes = sk.to_bytes();
+        let sk_restored = SecretKey::from_bytes(&bytes).expect("valid bytes");
+        assert_eq!(sk.to_bytes(), sk_restored.to_bytes());
+    }
+
+    #[test]
+    fn test_public_key_bytes_roundtrip() {
+        let sk = SecretKey::generate();
+        let pk = sk.public_key();
+        let bytes = pk.to_bytes();
+        let pk_restored = PublicKey::from_bytes(&bytes).expect("valid bytes");
+        assert_eq!(pk.to_bytes(), pk_restored.to_bytes());
+    }
+
+    #[test]
+    fn test_signature_bytes_roundtrip() {
+        let sk = SecretKey::generate();
+        let message = b"test message";
+        let sig = sk.sign(message);
+        let bytes = sig.to_bytes();
+        let sig_restored = Signature::from_bytes(&bytes).expect("valid bytes");
+        assert_eq!(sig.to_bytes(), sig_restored.to_bytes());
+    }
+
+    #[test]
+    fn test_sign_and_verify() {
+        let sk = SecretKey::generate();
+        let pk = sk.public_key();
+        let message = b"test message";
+        let sig = sk.sign(message);
+        assert!(sig.verify(&pk, message).is_ok());
+    }
+
+    #[test]
+    fn test_verify_wrong_message_fails() {
+        let sk = SecretKey::generate();
+        let pk = sk.public_key();
+        let message = b"test message";
+        let wrong_message = b"wrong message";
+        let sig = sk.sign(message);
+        assert!(sig.verify(&pk, wrong_message).is_err());
+    }
+
+    #[test]
+    fn test_verify_wrong_public_key_fails() {
+        let sk = SecretKey::generate();
+        let wrong_sk = SecretKey::generate();
+        let wrong_pk = wrong_sk.public_key();
+        let message = b"test message";
+        let sig = sk.sign(message);
+        assert!(sig.verify(&wrong_pk, message).is_err());
+    }
+
+    #[test]
+    fn test_public_key_hex_display() {
+        let sk = SecretKey::generate();
+        let pk = sk.public_key();
+        let display = format!("{}", pk);
+        assert!(display.starts_with("0x"));
+        assert_eq!(display.len(), 2 + PUBLIC_KEY_BYTES_LEN * 2);
+    }
+
+    #[test]
+    fn test_signature_hex_display() {
+        let sk = SecretKey::generate();
+        let sig = sk.sign(b"test");
+        let display = format!("{}", sig);
+        assert!(display.starts_with("0x"));
+        assert_eq!(display.len(), 2 + SIGNATURE_BYTES_LEN * 2);
+    }
+
+    #[test]
+    fn test_secret_key_debug_redacted() {
+        let sk = SecretKey::generate();
+        let debug = format!("{:?}", sk);
+        assert_eq!(debug, "SecretKey([REDACTED])");
+    }
+
+    #[test]
+    fn test_invalid_public_key_bytes() {
+        let invalid_bytes = vec![0u8; 10];
+        let result = PublicKey::from_bytes(&invalid_bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_secret_key_bytes() {
+        let invalid_bytes = vec![0u8; 10];
+        let result = SecretKey::from_bytes(&invalid_bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_signature_bytes() {
+        let invalid_bytes = vec![0u8; 10];
+        let result = Signature::from_bytes(&invalid_bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_aggregate_signatures() {
+        let sk1 = SecretKey::generate();
+        let sk2 = SecretKey::generate();
+        let pk1 = sk1.public_key();
+        let pk2 = sk2.public_key();
+        let message = b"aggregate test";
+
+        let sig1 = sk1.sign(message);
+        let sig2 = sk2.sign(message);
+
+        let agg_sig = Signature::aggregate(&[&sig1, &sig2]).expect("aggregation should succeed");
+        assert!(agg_sig.verify_aggregate(&[&pk1, &pk2], message).is_ok());
+    }
+
+    #[test]
+    fn test_aggregate_empty_fails() {
+        let result = Signature::aggregate(&[]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/rvc/src/crypto/error.rs
+++ b/crates/rvc/src/crypto/error.rs
@@ -1,0 +1,45 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum BlsError {
+    #[error("Invalid public key: {0}")]
+    InvalidPublicKey(String),
+
+    #[error("Invalid secret key: {0}")]
+    InvalidSecretKey(String),
+
+    #[error("Invalid signature: {0}")]
+    InvalidSignature(String),
+
+    #[error("Signature verification failed")]
+    SignatureVerificationFailed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_invalid_public_key_display() {
+        let err = BlsError::InvalidPublicKey("wrong length".to_string());
+        assert_eq!(err.to_string(), "Invalid public key: wrong length");
+    }
+
+    #[test]
+    fn test_invalid_secret_key_display() {
+        let err = BlsError::InvalidSecretKey("invalid bytes".to_string());
+        assert_eq!(err.to_string(), "Invalid secret key: invalid bytes");
+    }
+
+    #[test]
+    fn test_invalid_signature_display() {
+        let err = BlsError::InvalidSignature("malformed".to_string());
+        assert_eq!(err.to_string(), "Invalid signature: malformed");
+    }
+
+    #[test]
+    fn test_signature_verification_failed_display() {
+        let err = BlsError::SignatureVerificationFailed;
+        assert_eq!(err.to_string(), "Signature verification failed");
+    }
+}

--- a/crates/rvc/src/crypto/mod.rs
+++ b/crates/rvc/src/crypto/mod.rs
@@ -1,0 +1,8 @@
+mod bls;
+mod error;
+
+pub use bls::{
+    PublicKey, SecretKey, Signature, PUBLIC_KEY_BYTES_LEN, SECRET_KEY_BYTES_LEN,
+    SIGNATURE_BYTES_LEN,
+};
+pub use error::BlsError;

--- a/crates/rvc/src/lib.rs
+++ b/crates/rvc/src/lib.rs
@@ -1,6 +1,7 @@
 //! rvc - Rust Validator Client
 
 pub mod beacon;
+pub mod crypto;
 pub mod duty_tracker;
 
 pub mod proto {


### PR DESCRIPTION
## Summary

- Add `blst` crate (standard BLS library for Ethereum) with `hex` and `rand` dependencies
- Create `crypto` module with wrapper types for `PublicKey`, `SecretKey`, and `Signature`
- Implement byte conversion (`from_bytes`/`to_bytes`) for all types
- Add hex string display formatting (`0x` prefixed) for `PublicKey` and `Signature`
- Include signature aggregation and aggregate verification support
- Proper error handling with `BlsError` enum using `thiserror`

## Test Plan

- [x] All 72 unit tests pass (`cargo test -p rvc`)
- [x] Test key generation produces unique keys
- [x] Test byte round-trip conversion for all types
- [x] Test sign and verify workflow
- [x] Test verification fails with wrong message or wrong public key
- [x] Test hex display formatting
- [x] Test SecretKey debug output is redacted
- [x] Test invalid bytes produce appropriate errors
- [x] Test signature aggregation and aggregate verification
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes with no warnings

close #18

---
Generated with [Claude Code](https://claude.com/claude-code)