### PR TITLE
feat(crypto): implement EIP-2335 keystore parser (#19)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +559,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +696,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1345,7 +1375,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1499,6 +1529,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1796,10 +1835,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1919,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -2016,7 +2076,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "thiserror",
  "tokio",
  "tracing",
@@ -2053,16 +2113,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -2402,14 +2462,18 @@ dependencies = [
 name = "rvc"
 version = "0.1.0"
 dependencies = [
+ "aes",
  "beacon-client",
  "blst",
+ "ctr",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "hex",
+ "pbkdf2",
  "prost",
  "rand 0.8.5",
  "reqwest",
+ "scrypt",
  "serde",
  "serde_json",
  "sha2",
@@ -2418,6 +2482,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tracing",
+ "uuid",
  "wiremock",
 ]
 
@@ -2441,10 +2506,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "password-hash",
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "sec1"
@@ -2629,9 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -2734,18 +2820,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2816,7 +2902,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3147,6 +3233,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+dependencies = [
+ "getrandom 0.3.4",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3184,9 +3282,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -3475,9 +3573,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
@@ -3613,6 +3711,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,11 @@ rand = "0.8"
 ssz = { package = "ethereum_ssz", version = "0.9" }
 ssz_derive = { package = "ethereum_ssz_derive", version = "0.9" }
 sha2 = "0.10"
+scrypt = "0.11"
+pbkdf2 = "0.12"
+aes = "0.8"
+ctr = "0.9"
+uuid = { version = "1", features = ["v4", "serde"] }
 
 # Dev dependencies
 wiremock = "0.6"

--- a/crates/rvc/Cargo.toml
+++ b/crates/rvc/Cargo.toml
@@ -22,6 +22,11 @@ rand.workspace = true
 ssz.workspace = true
 ssz_derive.workspace = true
 sha2.workspace = true
+scrypt.workspace = true
+pbkdf2.workspace = true
+aes.workspace = true
+ctr.workspace = true
+uuid.workspace = true
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/crates/rvc/src/crypto/error.rs
+++ b/crates/rvc/src/crypto/error.rs
@@ -15,6 +15,45 @@ pub enum BlsError {
     SignatureVerificationFailed,
 }
 
+#[derive(Error, Debug)]
+pub enum KeystoreError {
+    #[error("Invalid JSON format: {0}")]
+    InvalidJson(#[from] serde_json::Error),
+
+    #[error("Unsupported keystore version: {0}")]
+    UnsupportedVersion(u32),
+
+    #[error("Unsupported KDF function: {0}")]
+    UnsupportedKdf(String),
+
+    #[error("Unsupported cipher function: {0}")]
+    UnsupportedCipher(String),
+
+    #[error("Unsupported checksum function: {0}")]
+    UnsupportedChecksum(String),
+
+    #[error("Invalid hex encoding: {0}")]
+    InvalidHex(#[from] hex::FromHexError),
+
+    #[error("Checksum mismatch: decryption failed")]
+    ChecksumMismatch,
+
+    #[error("Invalid scrypt parameters: {0}")]
+    InvalidScryptParams(String),
+
+    #[error("Key derivation failed: {0}")]
+    KeyDerivationFailed(String),
+
+    #[error("Decryption failed: {0}")]
+    DecryptionFailed(String),
+
+    #[error("Invalid secret key: {0}")]
+    InvalidSecretKey(#[from] BlsError),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -41,5 +80,23 @@ mod tests {
     fn test_signature_verification_failed_display() {
         let err = BlsError::SignatureVerificationFailed;
         assert_eq!(err.to_string(), "Signature verification failed");
+    }
+
+    #[test]
+    fn test_keystore_unsupported_version() {
+        let err = KeystoreError::UnsupportedVersion(3);
+        assert_eq!(err.to_string(), "Unsupported keystore version: 3");
+    }
+
+    #[test]
+    fn test_keystore_unsupported_kdf() {
+        let err = KeystoreError::UnsupportedKdf("argon2".to_string());
+        assert_eq!(err.to_string(), "Unsupported KDF function: argon2");
+    }
+
+    #[test]
+    fn test_keystore_checksum_mismatch() {
+        let err = KeystoreError::ChecksumMismatch;
+        assert_eq!(err.to_string(), "Checksum mismatch: decryption failed");
     }
 }

--- a/crates/rvc/src/crypto/keystore.rs
+++ b/crates/rvc/src/crypto/keystore.rs
@@ -1,0 +1,555 @@
+use std::fs;
+use std::path::Path;
+
+use aes::cipher::{KeyIvInit, StreamCipher};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use super::bls::SecretKey;
+use super::error::KeystoreError;
+
+type Aes128Ctr = ctr::Ctr64BE<aes::Aes128>;
+
+const KEYSTORE_VERSION: u32 = 4;
+const KDF_SCRYPT: &str = "scrypt";
+const KDF_PBKDF2: &str = "pbkdf2";
+const CIPHER_AES_128_CTR: &str = "aes-128-ctr";
+const CHECKSUM_SHA256: &str = "sha256";
+const DERIVED_KEY_LEN: usize = 32;
+const AES_KEY_LEN: usize = 16;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Keystore {
+    pub crypto: Crypto,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pubkey: Option<String>,
+    pub path: String,
+    pub uuid: Uuid,
+    pub version: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Crypto {
+    pub kdf: KdfModule,
+    pub checksum: ChecksumModule,
+    pub cipher: CipherModule,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KdfModule {
+    pub function: String,
+    pub params: KdfParams,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum KdfParams {
+    Scrypt(ScryptParams),
+    Pbkdf2(Pbkdf2Params),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScryptParams {
+    pub dklen: u32,
+    pub n: u32,
+    pub p: u32,
+    pub r: u32,
+    pub salt: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Pbkdf2Params {
+    pub dklen: u32,
+    pub c: u32,
+    pub prf: String,
+    pub salt: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChecksumModule {
+    pub function: String,
+    pub params: ChecksumParams,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChecksumParams {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CipherModule {
+    pub function: String,
+    pub params: CipherParams,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CipherParams {
+    pub iv: String,
+}
+
+impl Keystore {
+    pub fn from_json(json: &str) -> Result<Self, KeystoreError> {
+        let keystore: Keystore = serde_json::from_str(json)?;
+        keystore.validate()?;
+        Ok(keystore)
+    }
+
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, KeystoreError> {
+        let json = fs::read_to_string(path)?;
+        Self::from_json(&json)
+    }
+
+    fn validate(&self) -> Result<(), KeystoreError> {
+        if self.version != KEYSTORE_VERSION {
+            return Err(KeystoreError::UnsupportedVersion(self.version));
+        }
+
+        match self.crypto.kdf.function.as_str() {
+            KDF_SCRYPT | KDF_PBKDF2 => {}
+            other => return Err(KeystoreError::UnsupportedKdf(other.to_string())),
+        }
+
+        if self.crypto.cipher.function != CIPHER_AES_128_CTR {
+            return Err(KeystoreError::UnsupportedCipher(self.crypto.cipher.function.clone()));
+        }
+
+        if self.crypto.checksum.function != CHECKSUM_SHA256 {
+            return Err(KeystoreError::UnsupportedChecksum(self.crypto.checksum.function.clone()));
+        }
+
+        Ok(())
+    }
+
+    pub fn decrypt(&self, password: &[u8]) -> Result<SecretKey, KeystoreError> {
+        let derived_key = self.derive_key(password)?;
+        let ciphertext = hex::decode(&self.crypto.cipher.message)?;
+        self.verify_checksum(&derived_key, &ciphertext)?;
+        let plaintext = self.decrypt_ciphertext(&derived_key, &ciphertext)?;
+        SecretKey::from_bytes(&plaintext).map_err(KeystoreError::from)
+    }
+
+    fn derive_key(&self, password: &[u8]) -> Result<[u8; DERIVED_KEY_LEN], KeystoreError> {
+        match self.crypto.kdf.function.as_str() {
+            KDF_SCRYPT => self.derive_key_scrypt(password),
+            KDF_PBKDF2 => self.derive_key_pbkdf2(password),
+            other => Err(KeystoreError::UnsupportedKdf(other.to_string())),
+        }
+    }
+
+    fn derive_key_scrypt(&self, password: &[u8]) -> Result<[u8; DERIVED_KEY_LEN], KeystoreError> {
+        let params = match &self.crypto.kdf.params {
+            KdfParams::Scrypt(p) => p,
+            _ => {
+                return Err(KeystoreError::InvalidScryptParams(
+                    "expected scrypt params".to_string(),
+                ))
+            }
+        };
+
+        let salt = hex::decode(&params.salt)?;
+        let log_n = (params.n as f64).log2() as u8;
+
+        let scrypt_params = scrypt::Params::new(log_n, params.r, params.p, params.dklen as usize)
+            .map_err(|e| KeystoreError::InvalidScryptParams(e.to_string()))?;
+
+        let mut derived_key = [0u8; DERIVED_KEY_LEN];
+        scrypt::scrypt(password, &salt, &scrypt_params, &mut derived_key)
+            .map_err(|e| KeystoreError::KeyDerivationFailed(e.to_string()))?;
+
+        Ok(derived_key)
+    }
+
+    fn derive_key_pbkdf2(&self, password: &[u8]) -> Result<[u8; DERIVED_KEY_LEN], KeystoreError> {
+        let params = match &self.crypto.kdf.params {
+            KdfParams::Pbkdf2(p) => p,
+            _ => {
+                return Err(KeystoreError::KeyDerivationFailed(
+                    "expected pbkdf2 params".to_string(),
+                ))
+            }
+        };
+
+        if params.prf != "hmac-sha256" {
+            return Err(KeystoreError::KeyDerivationFailed(format!(
+                "unsupported PRF: {}",
+                params.prf
+            )));
+        }
+
+        let salt = hex::decode(&params.salt)?;
+        let mut derived_key = [0u8; DERIVED_KEY_LEN];
+
+        pbkdf2::pbkdf2_hmac::<Sha256>(password, &salt, params.c, &mut derived_key);
+
+        Ok(derived_key)
+    }
+
+    fn verify_checksum(
+        &self,
+        derived_key: &[u8; DERIVED_KEY_LEN],
+        ciphertext: &[u8],
+    ) -> Result<(), KeystoreError> {
+        let expected_checksum = hex::decode(&self.crypto.checksum.message)?;
+
+        let mut hasher = Sha256::new();
+        hasher.update(&derived_key[AES_KEY_LEN..DERIVED_KEY_LEN]);
+        hasher.update(ciphertext);
+        let computed_checksum = hasher.finalize();
+
+        if computed_checksum.as_slice() != expected_checksum {
+            return Err(KeystoreError::ChecksumMismatch);
+        }
+
+        Ok(())
+    }
+
+    fn decrypt_ciphertext(
+        &self,
+        derived_key: &[u8; DERIVED_KEY_LEN],
+        ciphertext: &[u8],
+    ) -> Result<Vec<u8>, KeystoreError> {
+        let iv = hex::decode(&self.crypto.cipher.params.iv)?;
+        let aes_key = &derived_key[..AES_KEY_LEN];
+
+        let mut cipher = Aes128Ctr::new(aes_key.into(), iv.as_slice().into());
+        let mut plaintext = ciphertext.to_vec();
+        cipher.apply_keystream(&mut plaintext);
+
+        Ok(plaintext)
+    }
+
+    pub fn pubkey_bytes(&self) -> Result<Option<Vec<u8>>, KeystoreError> {
+        match &self.pubkey {
+            Some(pk) => Ok(Some(hex::decode(pk)?)),
+            None => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // EIP-2335 official test vectors from https://eips.ethereum.org/EIPS/eip-2335
+    // Password: 0x7465737470617373776f7264f09f9491 (UTF-8: test password with emoji)
+    // Secret: 0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
+    const EIP2335_PASSWORD: &[u8] = &[
+        0x74, 0x65, 0x73, 0x74, 0x70, 0x61, 0x73, 0x73, 0x77, 0x6f, 0x72, 0x64, 0xf0, 0x9f, 0x94,
+        0x91,
+    ];
+    const EIP2335_SECRET_HEX: &str =
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+
+    const EIP2335_SCRYPT_TEST_VECTOR: &str = r#"
+    {
+        "crypto": {
+            "kdf": {
+                "function": "scrypt",
+                "params": {
+                    "dklen": 32,
+                    "n": 262144,
+                    "p": 1,
+                    "r": 8,
+                    "salt": "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
+                },
+                "message": ""
+            },
+            "checksum": {
+                "function": "sha256",
+                "params": {},
+                "message": "d2217fe5f3e9a1e34581ef8a78f7c9928e436d36dacc5e846690a5581e8ea484"
+            },
+            "cipher": {
+                "function": "aes-128-ctr",
+                "params": {
+                    "iv": "264daa3f303d7259501c93d997d84fe6"
+                },
+                "message": "06ae90d55fe0a6e9c5c3bc5b170827b2e5cce3929ed3f116c2811e6366dfe20f"
+            }
+        },
+        "description": "This is a test keystore that uses scrypt to secure the secret.",
+        "pubkey": "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07",
+        "path": "m/12381/60/3141592653/589793238",
+        "uuid": "1d85ae20-35c5-4611-98e8-aa14a633906f",
+        "version": 4
+    }
+    "#;
+
+    const EIP2335_PBKDF2_TEST_VECTOR: &str = r#"
+    {
+        "crypto": {
+            "kdf": {
+                "function": "pbkdf2",
+                "params": {
+                    "dklen": 32,
+                    "c": 262144,
+                    "prf": "hmac-sha256",
+                    "salt": "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
+                },
+                "message": ""
+            },
+            "checksum": {
+                "function": "sha256",
+                "params": {},
+                "message": "8a9f5d9912ed7e75ea794bc5a89bca5f193721d30868ade6f73043c6ea6febf1"
+            },
+            "cipher": {
+                "function": "aes-128-ctr",
+                "params": {
+                    "iv": "264daa3f303d7259501c93d997d84fe6"
+                },
+                "message": "cee03fde2af33149775b7223e7845e4fb2c8ae1792e5f99fe9ecf474cc8c16ad"
+            }
+        },
+        "description": "This is a test keystore that uses PBKDF2 to secure the secret.",
+        "pubkey": "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07",
+        "path": "m/12381/60/0/0",
+        "uuid": "64625def-3331-4eea-ab6f-782f3ed16a83",
+        "version": 4
+    }
+    "#;
+
+    #[test]
+    fn test_parse_scrypt_keystore() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        assert_eq!(keystore.version, 4);
+        assert_eq!(keystore.crypto.kdf.function, "scrypt");
+        assert_eq!(keystore.crypto.cipher.function, "aes-128-ctr");
+        assert_eq!(keystore.crypto.checksum.function, "sha256");
+        assert_eq!(keystore.path, "m/12381/60/3141592653/589793238");
+    }
+
+    #[test]
+    fn test_parse_pbkdf2_keystore() {
+        let keystore = Keystore::from_json(EIP2335_PBKDF2_TEST_VECTOR).expect("should parse");
+        assert_eq!(keystore.version, 4);
+        assert_eq!(keystore.crypto.kdf.function, "pbkdf2");
+        assert_eq!(keystore.crypto.cipher.function, "aes-128-ctr");
+        assert_eq!(keystore.crypto.checksum.function, "sha256");
+        assert_eq!(keystore.path, "m/12381/60/0/0");
+    }
+
+    #[test]
+    fn test_scrypt_params_extraction() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        match &keystore.crypto.kdf.params {
+            KdfParams::Scrypt(params) => {
+                assert_eq!(params.dklen, 32);
+                assert_eq!(params.n, 262144);
+                assert_eq!(params.p, 1);
+                assert_eq!(params.r, 8);
+            }
+            _ => panic!("expected scrypt params"),
+        }
+    }
+
+    #[test]
+    fn test_pbkdf2_params_extraction() {
+        let keystore = Keystore::from_json(EIP2335_PBKDF2_TEST_VECTOR).expect("should parse");
+        match &keystore.crypto.kdf.params {
+            KdfParams::Pbkdf2(params) => {
+                assert_eq!(params.dklen, 32);
+                assert_eq!(params.c, 262144);
+                assert_eq!(params.prf, "hmac-sha256");
+            }
+            _ => panic!("expected pbkdf2 params"),
+        }
+    }
+
+    #[test]
+    fn test_unsupported_version() {
+        let json = r#"
+        {
+            "crypto": {
+                "kdf": { "function": "scrypt", "params": { "dklen": 32, "n": 262144, "p": 1, "r": 8, "salt": "aa" }, "message": "" },
+                "checksum": { "function": "sha256", "params": {}, "message": "aa" },
+                "cipher": { "function": "aes-128-ctr", "params": { "iv": "aa" }, "message": "aa" }
+            },
+            "path": "",
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "version": 3
+        }
+        "#;
+        let result = Keystore::from_json(json);
+        assert!(matches!(result, Err(KeystoreError::UnsupportedVersion(3))));
+    }
+
+    #[test]
+    fn test_unsupported_kdf() {
+        let json = r#"
+        {
+            "crypto": {
+                "kdf": { "function": "argon2id", "params": { "dklen": 32, "n": 262144, "p": 1, "r": 8, "salt": "aa" }, "message": "" },
+                "checksum": { "function": "sha256", "params": {}, "message": "aa" },
+                "cipher": { "function": "aes-128-ctr", "params": { "iv": "aa" }, "message": "aa" }
+            },
+            "path": "",
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "version": 4
+        }
+        "#;
+        let result = Keystore::from_json(json);
+        assert!(matches!(result, Err(KeystoreError::UnsupportedKdf(_))));
+    }
+
+    #[test]
+    fn test_unsupported_cipher() {
+        let json = r#"
+        {
+            "crypto": {
+                "kdf": { "function": "scrypt", "params": { "dklen": 32, "n": 262144, "p": 1, "r": 8, "salt": "aa" }, "message": "" },
+                "checksum": { "function": "sha256", "params": {}, "message": "aa" },
+                "cipher": { "function": "aes-256-gcm", "params": { "iv": "aa" }, "message": "aa" }
+            },
+            "path": "",
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "version": 4
+        }
+        "#;
+        let result = Keystore::from_json(json);
+        assert!(matches!(result, Err(KeystoreError::UnsupportedCipher(_))));
+    }
+
+    #[test]
+    fn test_unsupported_checksum() {
+        let json = r#"
+        {
+            "crypto": {
+                "kdf": { "function": "scrypt", "params": { "dklen": 32, "n": 262144, "p": 1, "r": 8, "salt": "aa" }, "message": "" },
+                "checksum": { "function": "sha512", "params": {}, "message": "aa" },
+                "cipher": { "function": "aes-128-ctr", "params": { "iv": "aa" }, "message": "aa" }
+            },
+            "path": "",
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "version": 4
+        }
+        "#;
+        let result = Keystore::from_json(json);
+        assert!(matches!(result, Err(KeystoreError::UnsupportedChecksum(_))));
+    }
+
+    #[test]
+    fn test_uuid_parsing() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        assert_eq!(keystore.uuid.to_string(), "1d85ae20-35c5-4611-98e8-aa14a633906f");
+    }
+
+    #[test]
+    fn test_pubkey_extraction() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        let pubkey_bytes = keystore.pubkey_bytes().expect("should decode").unwrap();
+        assert_eq!(pubkey_bytes.len(), 48);
+    }
+
+    #[test]
+    fn test_optional_fields() {
+        let json = r#"
+        {
+            "crypto": {
+                "kdf": { "function": "scrypt", "params": { "dklen": 32, "n": 262144, "p": 1, "r": 8, "salt": "aa" }, "message": "" },
+                "checksum": { "function": "sha256", "params": {}, "message": "aa" },
+                "cipher": { "function": "aes-128-ctr", "params": { "iv": "aa" }, "message": "aa" }
+            },
+            "path": "m/12381/60/0/0",
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "version": 4
+        }
+        "#;
+        let keystore = Keystore::from_json(json).expect("should parse");
+        assert!(keystore.description.is_none());
+        assert!(keystore.pubkey.is_none());
+    }
+
+    #[test]
+    fn test_scrypt_key_derivation() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        let derived_key = keystore.derive_key(EIP2335_PASSWORD).expect("should derive key");
+        assert_eq!(derived_key.len(), 32);
+    }
+
+    #[test]
+    fn test_pbkdf2_key_derivation() {
+        let keystore = Keystore::from_json(EIP2335_PBKDF2_TEST_VECTOR).expect("should parse");
+        let derived_key = keystore.derive_key(EIP2335_PASSWORD).expect("should derive key");
+        assert_eq!(derived_key.len(), 32);
+    }
+
+    #[test]
+    fn test_scrypt_decrypt_eip2335_test_vector() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        let secret_key = keystore.decrypt(EIP2335_PASSWORD).expect("should decrypt");
+        let expected_secret = hex::decode(EIP2335_SECRET_HEX).expect("valid hex");
+        assert_eq!(secret_key.to_bytes().to_vec(), expected_secret);
+    }
+
+    #[test]
+    fn test_pbkdf2_decrypt_eip2335_test_vector() {
+        let keystore = Keystore::from_json(EIP2335_PBKDF2_TEST_VECTOR).expect("should parse");
+        let secret_key = keystore.decrypt(EIP2335_PASSWORD).expect("should decrypt");
+        let expected_secret = hex::decode(EIP2335_SECRET_HEX).expect("valid hex");
+        assert_eq!(secret_key.to_bytes().to_vec(), expected_secret);
+    }
+
+    #[test]
+    fn test_checksum_verification_failure_wrong_password() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        let wrong_password = "wrongpassword".as_bytes();
+        let result = keystore.decrypt(wrong_password);
+        assert!(matches!(result, Err(KeystoreError::ChecksumMismatch)));
+    }
+
+    #[test]
+    fn test_checksum_verification_failure_empty_password() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        let result = keystore.decrypt(&[]);
+        assert!(matches!(result, Err(KeystoreError::ChecksumMismatch)));
+    }
+
+    #[test]
+    fn test_serialize_keystore() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        let serialized = serde_json::to_string(&keystore).expect("should serialize");
+        let reparsed: Keystore = serde_json::from_str(&serialized).expect("should reparse");
+        assert_eq!(reparsed.version, keystore.version);
+        assert_eq!(reparsed.uuid, keystore.uuid);
+    }
+
+    #[test]
+    fn test_invalid_json() {
+        let result = Keystore::from_json("not valid json");
+        assert!(matches!(result, Err(KeystoreError::InvalidJson(_))));
+    }
+
+    #[test]
+    fn test_invalid_hex_in_salt() {
+        let json = r#"
+        {
+            "crypto": {
+                "kdf": { "function": "scrypt", "params": { "dklen": 32, "n": 262144, "p": 1, "r": 8, "salt": "not_hex!" }, "message": "" },
+                "checksum": { "function": "sha256", "params": {}, "message": "aa" },
+                "cipher": { "function": "aes-128-ctr", "params": { "iv": "aa" }, "message": "aa" }
+            },
+            "path": "m/12381/60/0/0",
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "version": 4
+        }
+        "#;
+        let keystore = Keystore::from_json(json).expect("should parse json");
+        let result = keystore.decrypt(b"test");
+        assert!(matches!(result, Err(KeystoreError::InvalidHex(_))));
+    }
+
+    #[test]
+    fn test_decrypted_key_can_sign() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        let secret_key = keystore.decrypt(EIP2335_PASSWORD).expect("should decrypt");
+        let message = b"test message";
+        let signature = secret_key.sign(message);
+        let public_key = secret_key.public_key();
+        assert!(signature.verify(&public_key, message).is_ok());
+    }
+}

--- a/crates/rvc/src/crypto/mod.rs
+++ b/crates/rvc/src/crypto/mod.rs
@@ -1,5 +1,6 @@
 mod bls;
 mod error;
+mod keystore;
 mod signing;
 mod types;
 
@@ -7,7 +8,8 @@ pub use bls::{
     PublicKey, SecretKey, Signature, PUBLIC_KEY_BYTES_LEN, SECRET_KEY_BYTES_LEN,
     SIGNATURE_BYTES_LEN,
 };
-pub use error::BlsError;
+pub use error::{BlsError, KeystoreError};
+pub use keystore::{KdfParams, Keystore, Pbkdf2Params, ScryptParams};
 pub use signing::{
     compute_domain, compute_fork_data_root, compute_signing_root, sign_attestation,
     DOMAIN_BEACON_ATTESTER,


### PR DESCRIPTION
## Summary
- Implement EIP-2335 encrypted keystore file parser for BLS12-381 validator keys
- Support both scrypt and pbkdf2 key derivation functions
- AES-128-CTR decryption with SHA-256 checksum verification
- Password-based decryption API that returns a BLS SecretKey

## Changes
- Add workspace dependencies: scrypt, pbkdf2, aes, ctr, sha2, uuid
- Create `keystore.rs` module with:
  - `Keystore` struct with JSON serialization/deserialization
  - `KdfParams` enum supporting ScryptParams and Pbkdf2Params
  - `Crypto`, `CipherModule`, `ChecksumModule` types
  - `decrypt()` method for password-based key decryption
  - `from_json()` and `from_file()` parsing methods
- Add `KeystoreError` variants to error.rs
- Export keystore types from crypto module

## Test plan
- [x] Parse scrypt keystore JSON
- [x] Parse pbkdf2 keystore JSON
- [x] Extract KDF parameters correctly
- [x] Validate unsupported versions/KDFs/ciphers/checksums
- [x] Key derivation with scrypt
- [x] Key derivation with pbkdf2
- [x] Full decryption with EIP-2335 official test vectors
- [x] Checksum verification failure on wrong password
- [x] Decrypted key can be used for signing

close #19

---
Generated with [Claude Code](https://claude.com/claude-code)