### PR TITLE
fix(crypto): add scrypt parameter validation in keystore parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "blst"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +534,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1363,7 +1387,10 @@ name = "rvc"
 version = "0.1.0"
 dependencies = [
  "beacon-client",
+ "blst",
+ "hex",
  "prost",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
@@ -1601,6 +1628,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -2282,6 +2318,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +559,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +696,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1345,7 +1375,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1499,6 +1529,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1796,10 +1835,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1919,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -2016,7 +2076,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "thiserror",
  "tokio",
  "tracing",
@@ -2053,16 +2113,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -2402,14 +2462,18 @@ dependencies = [
 name = "rvc"
 version = "0.1.0"
 dependencies = [
+ "aes",
  "beacon-client",
  "blst",
+ "ctr",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "hex",
+ "pbkdf2",
  "prost",
  "rand 0.8.5",
  "reqwest",
+ "scrypt",
  "serde",
  "serde_json",
  "sha2",
@@ -2418,6 +2482,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tracing",
+ "uuid",
  "wiremock",
 ]
 
@@ -2441,10 +2506,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "password-hash",
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "sec1"
@@ -2629,9 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -2734,18 +2820,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2816,7 +2902,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3147,6 +3233,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+dependencies = [
+ "getrandom 0.3.4",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3184,9 +3282,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -3475,9 +3573,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
@@ -3613,6 +3711,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2477,6 +2477,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror",
  "tokio",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-primitives"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6a0fb18dd5fb43ec5f0f6a20be1ce0287c79825827de5744afaa6c957737c33"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "foldhash",
+ "hashbrown 0.16.1",
+ "indexmap 2.13.0",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.9.2",
+ "rapidhash",
+ "ruint",
+ "rustc-hash",
+ "serde",
+ "sha3",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f70d83b765fdc080dbcd4f4db70d8d23fe4761f2f02ebfa9146b833900634b4"
+dependencies = [
+ "arrayvec",
+ "bytes",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +106,201 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,7 +329,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -107,7 +340,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -115,6 +348,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "autocfg"
@@ -170,10 +414,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "beacon-client"
@@ -189,10 +445,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "blst"
@@ -213,10 +505,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -271,7 +578,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -285,6 +592,125 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "const-hex"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "deadpool"
@@ -305,6 +731,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "syn 2.0.114",
+ "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,7 +803,33 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -320,6 +837,45 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "equivalent"
@@ -338,16 +894,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethereum_serde_utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
+dependencies = [
+ "alloy-primitives",
+ "hex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "ethereum_ssz"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
+dependencies = [
+ "alloy-primitives",
+ "ethereum_serde_utils",
+ "itertools 0.13.0",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "typenum",
+]
+
+[[package]]
+name = "ethereum_ssz_derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -362,6 +1002,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +1015,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -426,7 +1078,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -457,6 +1109,17 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -493,6 +1156,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +1196,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"
@@ -540,6 +1219,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "http"
@@ -745,6 +1433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +1460,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +1497,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -806,6 +1522,24 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -833,6 +1567,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +1609,12 @@ name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -922,6 +1694,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,6 +1743,34 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "parking_lot"
@@ -967,10 +1796,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
 
 [[package]]
 name = "petgraph"
@@ -999,7 +1844,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1013,6 +1858,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1039,7 +1894,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1049,6 +1924,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -1068,7 +1962,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -1077,7 +1971,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.114",
  "tempfile",
 ]
 
@@ -1088,10 +1982,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1102,6 +1996,12 @@ checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -1174,6 +2074,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +2098,7 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+ "serde",
 ]
 
 [[package]]
@@ -1230,6 +2137,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+ "serde",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8b5b858a440a0bc02625b62dd95131b9201aa9f69f411195dd4a7cfb1de3d7"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1309,6 +2235,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,10 +2259,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
+name = "ruint"
+version = "1.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
+ "bytes",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand 0.8.5",
+ "rand 0.9.2",
+ "rlp",
+ "ruint-macro",
+ "serde_core",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver 1.0.27",
+]
 
 [[package]]
 name = "rustix"
@@ -1383,17 +2387,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "rvc"
 version = "0.1.0"
 dependencies = [
  "beacon-client",
  "blst",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "hex",
  "prost",
  "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "tokio",
  "tonic",
@@ -1428,6 +2447,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,7 +2511,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1483,6 +2540,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
+dependencies = [
+ "cc",
+ "cfg-if",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,6 +2593,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1540,10 +2638,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1556,6 +2670,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1585,8 +2710,14 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1618,7 +2749,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1637,6 +2768,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -1689,7 +2829,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1724,6 +2864,36 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -1767,7 +2937,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1854,7 +3024,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1899,10 +3069,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -1939,6 +3151,21 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"
@@ -2010,7 +3237,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -2215,6 +3442,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,6 +3486,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,7 +3513,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -2289,7 +3534,7 @@ checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2309,7 +3554,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -2330,7 +3575,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2363,7 +3608,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,11 @@ rand = "0.8"
 ssz = { package = "ethereum_ssz", version = "0.9" }
 ssz_derive = { package = "ethereum_ssz_derive", version = "0.9" }
 sha2 = "0.10"
+scrypt = "0.11"
+pbkdf2 = "0.12"
+aes = "0.8"
+ctr = "0.9"
+uuid = { version = "1", features = ["v4", "serde"] }
 
 # Dev dependencies
 wiremock = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ tonic = "0.12"
 prost = "0.13"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
+# Crypto
+blst = "0.3"
+hex = "0.4"
+rand = "0.8"
+
 # Dev dependencies
 wiremock = "0.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 blst = "0.3"
 hex = "0.4"
 rand = "0.8"
+ssz = { package = "ethereum_ssz", version = "0.9" }
+ssz_derive = { package = "ethereum_ssz_derive", version = "0.9" }
+sha2 = "0.10"
 
 # Dev dependencies
 wiremock = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ ctr = "0.9"
 uuid = { version = "1", features = ["v4", "serde"] }
 
 # Dev dependencies
+tempfile = "3"
 wiremock = "0.6"
 
 [workspace.dependencies.tonic-build]

--- a/crates/rvc/Cargo.toml
+++ b/crates/rvc/Cargo.toml
@@ -16,6 +16,9 @@ tracing.workspace = true
 tonic.workspace = true
 prost.workspace = true
 reqwest.workspace = true
+blst.workspace = true
+hex.workspace = true
+rand.workspace = true
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/crates/rvc/Cargo.toml
+++ b/crates/rvc/Cargo.toml
@@ -32,4 +32,5 @@ uuid.workspace = true
 tonic-build.workspace = true
 
 [dev-dependencies]
+tempfile.workspace = true
 wiremock.workspace = true

--- a/crates/rvc/Cargo.toml
+++ b/crates/rvc/Cargo.toml
@@ -19,6 +19,9 @@ reqwest.workspace = true
 blst.workspace = true
 hex.workspace = true
 rand.workspace = true
+ssz.workspace = true
+ssz_derive.workspace = true
+sha2.workspace = true
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/crates/rvc/Cargo.toml
+++ b/crates/rvc/Cargo.toml
@@ -22,6 +22,11 @@ rand.workspace = true
 ssz.workspace = true
 ssz_derive.workspace = true
 sha2.workspace = true
+scrypt.workspace = true
+pbkdf2.workspace = true
+aes.workspace = true
+ctr.workspace = true
+uuid.workspace = true
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/crates/rvc/src/crypto/bls.rs
+++ b/crates/rvc/src/crypto/bls.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::hash::{Hash, Hasher};
 
 use blst::min_pk::{
     AggregateSignature, PublicKey as BlstPublicKey, SecretKey as BlstSecretKey,
@@ -39,6 +40,12 @@ impl fmt::Display for PublicKey {
 impl fmt::Debug for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "PublicKey({})", self)
+    }
+}
+
+impl Hash for PublicKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.to_bytes().hash(state);
     }
 }
 

--- a/crates/rvc/src/crypto/bls.rs
+++ b/crates/rvc/src/crypto/bls.rs
@@ -1,0 +1,286 @@
+use std::fmt;
+
+use blst::min_pk::{
+    AggregateSignature, PublicKey as BlstPublicKey, SecretKey as BlstSecretKey,
+    Signature as BlstSignature,
+};
+use blst::BLST_ERROR;
+use rand::RngCore;
+
+use super::error::BlsError;
+
+const DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
+
+pub const PUBLIC_KEY_BYTES_LEN: usize = 48;
+pub const SECRET_KEY_BYTES_LEN: usize = 32;
+pub const SIGNATURE_BYTES_LEN: usize = 96;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct PublicKey(BlstPublicKey);
+
+impl PublicKey {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, BlsError> {
+        BlstPublicKey::from_bytes(bytes)
+            .map(PublicKey)
+            .map_err(|e| BlsError::InvalidPublicKey(format!("{:?}", e)))
+    }
+
+    pub fn to_bytes(&self) -> [u8; PUBLIC_KEY_BYTES_LEN] {
+        self.0.to_bytes()
+    }
+}
+
+impl fmt::Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "0x{}", hex::encode(self.to_bytes()))
+    }
+}
+
+impl fmt::Debug for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PublicKey({})", self)
+    }
+}
+
+#[derive(Clone)]
+pub struct SecretKey(BlstSecretKey);
+
+impl SecretKey {
+    pub fn generate() -> Self {
+        let mut ikm = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut ikm);
+        SecretKey(
+            BlstSecretKey::key_gen(&ikm, &[])
+                .expect("key generation should not fail with valid IKM"),
+        )
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, BlsError> {
+        BlstSecretKey::from_bytes(bytes)
+            .map(SecretKey)
+            .map_err(|e| BlsError::InvalidSecretKey(format!("{:?}", e)))
+    }
+
+    pub fn to_bytes(&self) -> [u8; SECRET_KEY_BYTES_LEN] {
+        self.0.to_bytes()
+    }
+
+    pub fn public_key(&self) -> PublicKey {
+        PublicKey(self.0.sk_to_pk())
+    }
+
+    pub fn sign(&self, message: &[u8]) -> Signature {
+        Signature(self.0.sign(message, DST, &[]))
+    }
+}
+
+impl fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SecretKey([REDACTED])")
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct Signature(BlstSignature);
+
+impl Signature {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, BlsError> {
+        BlstSignature::from_bytes(bytes)
+            .map(Signature)
+            .map_err(|e| BlsError::InvalidSignature(format!("{:?}", e)))
+    }
+
+    pub fn to_bytes(&self) -> [u8; SIGNATURE_BYTES_LEN] {
+        self.0.to_bytes()
+    }
+
+    pub fn verify(&self, public_key: &PublicKey, message: &[u8]) -> Result<(), BlsError> {
+        let result = self.0.verify(true, message, DST, &[], &public_key.0, true);
+        if result == BLST_ERROR::BLST_SUCCESS {
+            Ok(())
+        } else {
+            Err(BlsError::SignatureVerificationFailed)
+        }
+    }
+
+    pub fn aggregate(signatures: &[&Signature]) -> Result<Self, BlsError> {
+        if signatures.is_empty() {
+            return Err(BlsError::InvalidSignature("cannot aggregate empty list".to_string()));
+        }
+
+        let blst_sigs: Vec<&BlstSignature> = signatures.iter().map(|s| &s.0).collect();
+        let agg = AggregateSignature::aggregate(&blst_sigs, true)
+            .map_err(|e| BlsError::InvalidSignature(format!("{:?}", e)))?;
+
+        Ok(Signature(agg.to_signature()))
+    }
+
+    pub fn verify_aggregate(
+        &self,
+        public_keys: &[&PublicKey],
+        message: &[u8],
+    ) -> Result<(), BlsError> {
+        if public_keys.is_empty() {
+            return Err(BlsError::InvalidPublicKey(
+                "cannot verify with empty public key list".to_string(),
+            ));
+        }
+
+        let blst_pks: Vec<&BlstPublicKey> = public_keys.iter().map(|pk| &pk.0).collect();
+        let msgs: Vec<&[u8]> = vec![message; public_keys.len()];
+
+        let result = self.0.aggregate_verify(true, &msgs, DST, &blst_pks, true);
+        if result == BLST_ERROR::BLST_SUCCESS {
+            Ok(())
+        } else {
+            Err(BlsError::SignatureVerificationFailed)
+        }
+    }
+}
+
+impl fmt::Display for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "0x{}", hex::encode(self.to_bytes()))
+    }
+}
+
+impl fmt::Debug for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Signature({})", self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_secret_key_generation() {
+        let sk1 = SecretKey::generate();
+        let sk2 = SecretKey::generate();
+        assert_ne!(sk1.to_bytes(), sk2.to_bytes());
+    }
+
+    #[test]
+    fn test_secret_key_bytes_roundtrip() {
+        let sk = SecretKey::generate();
+        let bytes = sk.to_bytes();
+        let sk_restored = SecretKey::from_bytes(&bytes).expect("valid bytes");
+        assert_eq!(sk.to_bytes(), sk_restored.to_bytes());
+    }
+
+    #[test]
+    fn test_public_key_bytes_roundtrip() {
+        let sk = SecretKey::generate();
+        let pk = sk.public_key();
+        let bytes = pk.to_bytes();
+        let pk_restored = PublicKey::from_bytes(&bytes).expect("valid bytes");
+        assert_eq!(pk.to_bytes(), pk_restored.to_bytes());
+    }
+
+    #[test]
+    fn test_signature_bytes_roundtrip() {
+        let sk = SecretKey::generate();
+        let message = b"test message";
+        let sig = sk.sign(message);
+        let bytes = sig.to_bytes();
+        let sig_restored = Signature::from_bytes(&bytes).expect("valid bytes");
+        assert_eq!(sig.to_bytes(), sig_restored.to_bytes());
+    }
+
+    #[test]
+    fn test_sign_and_verify() {
+        let sk = SecretKey::generate();
+        let pk = sk.public_key();
+        let message = b"test message";
+        let sig = sk.sign(message);
+        assert!(sig.verify(&pk, message).is_ok());
+    }
+
+    #[test]
+    fn test_verify_wrong_message_fails() {
+        let sk = SecretKey::generate();
+        let pk = sk.public_key();
+        let message = b"test message";
+        let wrong_message = b"wrong message";
+        let sig = sk.sign(message);
+        assert!(sig.verify(&pk, wrong_message).is_err());
+    }
+
+    #[test]
+    fn test_verify_wrong_public_key_fails() {
+        let sk = SecretKey::generate();
+        let wrong_sk = SecretKey::generate();
+        let wrong_pk = wrong_sk.public_key();
+        let message = b"test message";
+        let sig = sk.sign(message);
+        assert!(sig.verify(&wrong_pk, message).is_err());
+    }
+
+    #[test]
+    fn test_public_key_hex_display() {
+        let sk = SecretKey::generate();
+        let pk = sk.public_key();
+        let display = format!("{}", pk);
+        assert!(display.starts_with("0x"));
+        assert_eq!(display.len(), 2 + PUBLIC_KEY_BYTES_LEN * 2);
+    }
+
+    #[test]
+    fn test_signature_hex_display() {
+        let sk = SecretKey::generate();
+        let sig = sk.sign(b"test");
+        let display = format!("{}", sig);
+        assert!(display.starts_with("0x"));
+        assert_eq!(display.len(), 2 + SIGNATURE_BYTES_LEN * 2);
+    }
+
+    #[test]
+    fn test_secret_key_debug_redacted() {
+        let sk = SecretKey::generate();
+        let debug = format!("{:?}", sk);
+        assert_eq!(debug, "SecretKey([REDACTED])");
+    }
+
+    #[test]
+    fn test_invalid_public_key_bytes() {
+        let invalid_bytes = vec![0u8; 10];
+        let result = PublicKey::from_bytes(&invalid_bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_secret_key_bytes() {
+        let invalid_bytes = vec![0u8; 10];
+        let result = SecretKey::from_bytes(&invalid_bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_signature_bytes() {
+        let invalid_bytes = vec![0u8; 10];
+        let result = Signature::from_bytes(&invalid_bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_aggregate_signatures() {
+        let sk1 = SecretKey::generate();
+        let sk2 = SecretKey::generate();
+        let pk1 = sk1.public_key();
+        let pk2 = sk2.public_key();
+        let message = b"aggregate test";
+
+        let sig1 = sk1.sign(message);
+        let sig2 = sk2.sign(message);
+
+        let agg_sig = Signature::aggregate(&[&sig1, &sig2]).expect("aggregation should succeed");
+        assert!(agg_sig.verify_aggregate(&[&pk1, &pk2], message).is_ok());
+    }
+
+    #[test]
+    fn test_aggregate_empty_fails() {
+        let result = Signature::aggregate(&[]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/rvc/src/crypto/error.rs
+++ b/crates/rvc/src/crypto/error.rs
@@ -15,6 +15,45 @@ pub enum BlsError {
     SignatureVerificationFailed,
 }
 
+#[derive(Error, Debug)]
+pub enum KeystoreError {
+    #[error("Invalid JSON format: {0}")]
+    InvalidJson(#[from] serde_json::Error),
+
+    #[error("Unsupported keystore version: {0}")]
+    UnsupportedVersion(u32),
+
+    #[error("Unsupported KDF function: {0}")]
+    UnsupportedKdf(String),
+
+    #[error("Unsupported cipher function: {0}")]
+    UnsupportedCipher(String),
+
+    #[error("Unsupported checksum function: {0}")]
+    UnsupportedChecksum(String),
+
+    #[error("Invalid hex encoding: {0}")]
+    InvalidHex(#[from] hex::FromHexError),
+
+    #[error("Checksum mismatch: decryption failed")]
+    ChecksumMismatch,
+
+    #[error("Invalid scrypt parameters: {0}")]
+    InvalidScryptParams(String),
+
+    #[error("Key derivation failed: {0}")]
+    KeyDerivationFailed(String),
+
+    #[error("Decryption failed: {0}")]
+    DecryptionFailed(String),
+
+    #[error("Invalid secret key: {0}")]
+    InvalidSecretKey(#[from] BlsError),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -41,5 +80,23 @@ mod tests {
     fn test_signature_verification_failed_display() {
         let err = BlsError::SignatureVerificationFailed;
         assert_eq!(err.to_string(), "Signature verification failed");
+    }
+
+    #[test]
+    fn test_keystore_unsupported_version() {
+        let err = KeystoreError::UnsupportedVersion(3);
+        assert_eq!(err.to_string(), "Unsupported keystore version: 3");
+    }
+
+    #[test]
+    fn test_keystore_unsupported_kdf() {
+        let err = KeystoreError::UnsupportedKdf("argon2".to_string());
+        assert_eq!(err.to_string(), "Unsupported KDF function: argon2");
+    }
+
+    #[test]
+    fn test_keystore_checksum_mismatch() {
+        let err = KeystoreError::ChecksumMismatch;
+        assert_eq!(err.to_string(), "Checksum mismatch: decryption failed");
     }
 }

--- a/crates/rvc/src/crypto/error.rs
+++ b/crates/rvc/src/crypto/error.rs
@@ -1,0 +1,45 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum BlsError {
+    #[error("Invalid public key: {0}")]
+    InvalidPublicKey(String),
+
+    #[error("Invalid secret key: {0}")]
+    InvalidSecretKey(String),
+
+    #[error("Invalid signature: {0}")]
+    InvalidSignature(String),
+
+    #[error("Signature verification failed")]
+    SignatureVerificationFailed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_invalid_public_key_display() {
+        let err = BlsError::InvalidPublicKey("wrong length".to_string());
+        assert_eq!(err.to_string(), "Invalid public key: wrong length");
+    }
+
+    #[test]
+    fn test_invalid_secret_key_display() {
+        let err = BlsError::InvalidSecretKey("invalid bytes".to_string());
+        assert_eq!(err.to_string(), "Invalid secret key: invalid bytes");
+    }
+
+    #[test]
+    fn test_invalid_signature_display() {
+        let err = BlsError::InvalidSignature("malformed".to_string());
+        assert_eq!(err.to_string(), "Invalid signature: malformed");
+    }
+
+    #[test]
+    fn test_signature_verification_failed_display() {
+        let err = BlsError::SignatureVerificationFailed;
+        assert_eq!(err.to_string(), "Signature verification failed");
+    }
+}

--- a/crates/rvc/src/crypto/error.rs
+++ b/crates/rvc/src/crypto/error.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -54,6 +56,32 @@ pub enum KeystoreError {
     Io(#[from] std::io::Error),
 }
 
+#[derive(Error, Debug)]
+pub enum KeyManagerError {
+    #[error("Directory not found: {0}")]
+    DirectoryNotFound(PathBuf),
+
+    #[error("No keystore files found in directory")]
+    NoKeystoreFiles,
+
+    #[error("Failed to load keystore from {path}: {source}")]
+    KeystoreLoadFailed {
+        path: PathBuf,
+        #[source]
+        source: KeystoreError,
+    },
+
+    #[error("Failed to decrypt keystore from {path}: {source}")]
+    DecryptionFailed {
+        path: PathBuf,
+        #[source]
+        source: KeystoreError,
+    },
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -98,5 +126,17 @@ mod tests {
     fn test_keystore_checksum_mismatch() {
         let err = KeystoreError::ChecksumMismatch;
         assert_eq!(err.to_string(), "Checksum mismatch: decryption failed");
+    }
+
+    #[test]
+    fn test_key_manager_directory_not_found() {
+        let err = KeyManagerError::DirectoryNotFound(PathBuf::from("/nonexistent/path"));
+        assert_eq!(err.to_string(), "Directory not found: /nonexistent/path");
+    }
+
+    #[test]
+    fn test_key_manager_no_keystore_files() {
+        let err = KeyManagerError::NoKeystoreFiles;
+        assert_eq!(err.to_string(), "No keystore files found in directory");
     }
 }

--- a/crates/rvc/src/crypto/key_manager.rs
+++ b/crates/rvc/src/crypto/key_manager.rs
@@ -1,0 +1,385 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use tracing::warn;
+
+use super::bls::{PublicKey, SecretKey, PUBLIC_KEY_BYTES_LEN};
+use super::error::KeyManagerError;
+use super::keystore::Keystore;
+
+pub struct KeyManager {
+    keys: HashMap<[u8; PUBLIC_KEY_BYTES_LEN], SecretKey>,
+}
+
+impl KeyManager {
+    pub fn new() -> Self {
+        Self { keys: HashMap::new() }
+    }
+
+    /// Loads all keystore files from a directory.
+    ///
+    /// The `passwords` map uses public key hex strings (without 0x prefix) as keys
+    /// and the corresponding password strings as values.
+    ///
+    /// Corrupted or unreadable keystores are logged and skipped.
+    pub fn load_from_directory<P: AsRef<Path>>(
+        path: P,
+        passwords: &HashMap<String, String>,
+    ) -> Result<Self, KeyManagerError> {
+        let dir_path = path.as_ref();
+
+        if !dir_path.exists() {
+            return Err(KeyManagerError::DirectoryNotFound(dir_path.to_path_buf()));
+        }
+
+        if !dir_path.is_dir() {
+            return Err(KeyManagerError::DirectoryNotFound(dir_path.to_path_buf()));
+        }
+
+        let mut manager = Self::new();
+        let mut found_any_keystore = false;
+
+        let entries = fs::read_dir(dir_path)?;
+
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(e) => {
+                    warn!("Failed to read directory entry: {}", e);
+                    continue;
+                }
+            };
+
+            let file_path = entry.path();
+
+            if !file_path.is_file() {
+                continue;
+            }
+
+            let extension = file_path.extension().and_then(|ext| ext.to_str());
+            if extension != Some("json") {
+                continue;
+            }
+
+            found_any_keystore = true;
+
+            let keystore = match Keystore::from_file(&file_path) {
+                Ok(k) => k,
+                Err(e) => {
+                    warn!("Failed to load keystore from {:?}: {}", file_path, e);
+                    continue;
+                }
+            };
+
+            let pubkey_hex = match &keystore.pubkey {
+                Some(pk) => pk.clone(),
+                None => {
+                    warn!("Keystore {:?} has no public key field, skipping", file_path);
+                    continue;
+                }
+            };
+
+            let password = match passwords.get(&pubkey_hex) {
+                Some(p) => p,
+                None => {
+                    warn!(
+                        "No password found for public key {} in {:?}, skipping",
+                        pubkey_hex, file_path
+                    );
+                    continue;
+                }
+            };
+
+            let secret_key = match keystore.decrypt(password.as_bytes()) {
+                Ok(sk) => sk,
+                Err(e) => {
+                    warn!("Failed to decrypt keystore {:?}: {}", file_path, e);
+                    continue;
+                }
+            };
+
+            let public_key = secret_key.public_key();
+            manager.keys.insert(public_key.to_bytes(), secret_key);
+        }
+
+        if !found_any_keystore {
+            return Err(KeyManagerError::NoKeystoreFiles);
+        }
+
+        Ok(manager)
+    }
+
+    pub fn get_secret_key(&self, pubkey: &PublicKey) -> Option<&SecretKey> {
+        self.keys.get(&pubkey.to_bytes())
+    }
+
+    pub fn list_public_keys(&self) -> Vec<PublicKey> {
+        self.keys.keys().filter_map(|bytes| PublicKey::from_bytes(bytes).ok()).collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.keys.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+}
+
+impl Default for KeyManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::Write;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    const TEST_KEYSTORE_PBKDF2: &str = r#"
+    {
+        "crypto": {
+            "kdf": {
+                "function": "pbkdf2",
+                "params": {
+                    "dklen": 32,
+                    "c": 262144,
+                    "prf": "hmac-sha256",
+                    "salt": "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
+                },
+                "message": ""
+            },
+            "checksum": {
+                "function": "sha256",
+                "params": {},
+                "message": "8a9f5d9912ed7e75ea794bc5a89bca5f193721d30868ade6f73043c6ea6febf1"
+            },
+            "cipher": {
+                "function": "aes-128-ctr",
+                "params": {
+                    "iv": "264daa3f303d7259501c93d997d84fe6"
+                },
+                "message": "cee03fde2af33149775b7223e7845e4fb2c8ae1792e5f99fe9ecf474cc8c16ad"
+            }
+        },
+        "description": "Test keystore",
+        "pubkey": "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07",
+        "path": "m/12381/60/0/0",
+        "uuid": "64625def-3331-4eea-ab6f-782f3ed16a83",
+        "version": 4
+    }
+    "#;
+
+    const TEST_PASSWORD: &[u8] = &[
+        0x74, 0x65, 0x73, 0x74, 0x70, 0x61, 0x73, 0x73, 0x77, 0x6f, 0x72, 0x64, 0xf0, 0x9f, 0x94,
+        0x91,
+    ];
+
+    const TEST_PUBKEY_HEX: &str =
+        "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07";
+
+    fn create_test_keystore_file(dir: &TempDir, filename: &str, content: &str) {
+        let file_path = dir.path().join(filename);
+        let mut file = File::create(file_path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+    }
+
+    fn test_password_string() -> String {
+        String::from_utf8(TEST_PASSWORD.to_vec()).unwrap()
+    }
+
+    #[test]
+    fn test_new_key_manager_is_empty() {
+        let manager = KeyManager::new();
+        assert!(manager.is_empty());
+        assert_eq!(manager.len(), 0);
+    }
+
+    #[test]
+    fn test_load_from_directory_not_found() {
+        let passwords = HashMap::new();
+        let result = KeyManager::load_from_directory("/nonexistent/path", &passwords);
+        assert!(matches!(result, Err(KeyManagerError::DirectoryNotFound(_))));
+    }
+
+    #[test]
+    fn test_load_from_directory_empty() {
+        let temp_dir = TempDir::new().unwrap();
+        let passwords = HashMap::new();
+        let result = KeyManager::load_from_directory(temp_dir.path(), &passwords);
+        assert!(matches!(result, Err(KeyManagerError::NoKeystoreFiles)));
+    }
+
+    #[test]
+    fn test_load_from_directory_with_valid_keystore() {
+        let temp_dir = TempDir::new().unwrap();
+        create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
+
+        let mut passwords = HashMap::new();
+        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_string());
+
+        let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
+        assert_eq!(manager.len(), 1);
+        assert!(!manager.is_empty());
+    }
+
+    #[test]
+    fn test_get_secret_key() {
+        let temp_dir = TempDir::new().unwrap();
+        create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
+
+        let mut passwords = HashMap::new();
+        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_string());
+
+        let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
+
+        let pubkey_bytes = hex::decode(TEST_PUBKEY_HEX).unwrap();
+        let pubkey = PublicKey::from_bytes(&pubkey_bytes).unwrap();
+
+        let secret_key = manager.get_secret_key(&pubkey);
+        assert!(secret_key.is_some());
+
+        let sk = secret_key.unwrap();
+        assert_eq!(sk.public_key().to_bytes(), pubkey.to_bytes());
+    }
+
+    #[test]
+    fn test_get_secret_key_not_found() {
+        let temp_dir = TempDir::new().unwrap();
+        create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
+
+        let mut passwords = HashMap::new();
+        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_string());
+
+        let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
+
+        let other_sk = SecretKey::generate();
+        let other_pk = other_sk.public_key();
+
+        assert!(manager.get_secret_key(&other_pk).is_none());
+    }
+
+    #[test]
+    fn test_list_public_keys() {
+        let temp_dir = TempDir::new().unwrap();
+        create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
+
+        let mut passwords = HashMap::new();
+        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_string());
+
+        let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
+
+        let public_keys = manager.list_public_keys();
+        assert_eq!(public_keys.len(), 1);
+
+        let expected_pubkey_bytes = hex::decode(TEST_PUBKEY_HEX).unwrap();
+        assert_eq!(public_keys[0].to_bytes().to_vec(), expected_pubkey_bytes);
+    }
+
+    #[test]
+    fn test_graceful_handling_of_corrupted_keystore() {
+        let temp_dir = TempDir::new().unwrap();
+        create_test_keystore_file(&temp_dir, "corrupted.json", "{ invalid json }");
+        create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
+
+        let mut passwords = HashMap::new();
+        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_string());
+
+        let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
+        assert_eq!(manager.len(), 1);
+    }
+
+    #[test]
+    fn test_graceful_handling_of_wrong_password() {
+        let temp_dir = TempDir::new().unwrap();
+        create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
+
+        let mut passwords = HashMap::new();
+        passwords.insert(TEST_PUBKEY_HEX.to_string(), "wrong_password".to_string());
+
+        let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
+        assert!(manager.is_empty());
+    }
+
+    #[test]
+    fn test_graceful_handling_of_missing_password() {
+        let temp_dir = TempDir::new().unwrap();
+        create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
+
+        let passwords = HashMap::new();
+
+        let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
+        assert!(manager.is_empty());
+    }
+
+    #[test]
+    fn test_ignores_non_json_files() {
+        let temp_dir = TempDir::new().unwrap();
+        create_test_keystore_file(&temp_dir, "readme.txt", "This is not a keystore");
+        create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
+
+        let mut passwords = HashMap::new();
+        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_string());
+
+        let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
+        assert_eq!(manager.len(), 1);
+    }
+
+    #[test]
+    fn test_keystore_without_pubkey_field() {
+        let keystore_without_pubkey = r#"
+        {
+            "crypto": {
+                "kdf": { "function": "scrypt", "params": { "dklen": 32, "n": 262144, "p": 1, "r": 8, "salt": "aa" }, "message": "" },
+                "checksum": { "function": "sha256", "params": {}, "message": "aa" },
+                "cipher": { "function": "aes-128-ctr", "params": { "iv": "aa" }, "message": "aa" }
+            },
+            "path": "m/12381/60/0/0",
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "version": 4
+        }
+        "#;
+
+        let temp_dir = TempDir::new().unwrap();
+        create_test_keystore_file(&temp_dir, "no_pubkey.json", keystore_without_pubkey);
+        create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
+
+        let mut passwords = HashMap::new();
+        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_string());
+
+        let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
+        assert_eq!(manager.len(), 1);
+    }
+
+    #[test]
+    fn test_default_impl() {
+        let manager = KeyManager::default();
+        assert!(manager.is_empty());
+    }
+
+    #[test]
+    fn test_secret_key_can_sign() {
+        let temp_dir = TempDir::new().unwrap();
+        create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
+
+        let mut passwords = HashMap::new();
+        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_string());
+
+        let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
+
+        let pubkey_bytes = hex::decode(TEST_PUBKEY_HEX).unwrap();
+        let pubkey = PublicKey::from_bytes(&pubkey_bytes).unwrap();
+
+        let secret_key = manager.get_secret_key(&pubkey).unwrap();
+        let message = b"test message";
+        let signature = secret_key.sign(message);
+
+        assert!(signature.verify(&pubkey, message).is_ok());
+    }
+}

--- a/crates/rvc/src/crypto/keystore.rs
+++ b/crates/rvc/src/crypto/keystore.rs
@@ -1,0 +1,555 @@
+use std::fs;
+use std::path::Path;
+
+use aes::cipher::{KeyIvInit, StreamCipher};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use super::bls::SecretKey;
+use super::error::KeystoreError;
+
+type Aes128Ctr = ctr::Ctr64BE<aes::Aes128>;
+
+const KEYSTORE_VERSION: u32 = 4;
+const KDF_SCRYPT: &str = "scrypt";
+const KDF_PBKDF2: &str = "pbkdf2";
+const CIPHER_AES_128_CTR: &str = "aes-128-ctr";
+const CHECKSUM_SHA256: &str = "sha256";
+const DERIVED_KEY_LEN: usize = 32;
+const AES_KEY_LEN: usize = 16;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Keystore {
+    pub crypto: Crypto,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pubkey: Option<String>,
+    pub path: String,
+    pub uuid: Uuid,
+    pub version: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Crypto {
+    pub kdf: KdfModule,
+    pub checksum: ChecksumModule,
+    pub cipher: CipherModule,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KdfModule {
+    pub function: String,
+    pub params: KdfParams,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum KdfParams {
+    Scrypt(ScryptParams),
+    Pbkdf2(Pbkdf2Params),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScryptParams {
+    pub dklen: u32,
+    pub n: u32,
+    pub p: u32,
+    pub r: u32,
+    pub salt: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Pbkdf2Params {
+    pub dklen: u32,
+    pub c: u32,
+    pub prf: String,
+    pub salt: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChecksumModule {
+    pub function: String,
+    pub params: ChecksumParams,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChecksumParams {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CipherModule {
+    pub function: String,
+    pub params: CipherParams,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CipherParams {
+    pub iv: String,
+}
+
+impl Keystore {
+    pub fn from_json(json: &str) -> Result<Self, KeystoreError> {
+        let keystore: Keystore = serde_json::from_str(json)?;
+        keystore.validate()?;
+        Ok(keystore)
+    }
+
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, KeystoreError> {
+        let json = fs::read_to_string(path)?;
+        Self::from_json(&json)
+    }
+
+    fn validate(&self) -> Result<(), KeystoreError> {
+        if self.version != KEYSTORE_VERSION {
+            return Err(KeystoreError::UnsupportedVersion(self.version));
+        }
+
+        match self.crypto.kdf.function.as_str() {
+            KDF_SCRYPT | KDF_PBKDF2 => {}
+            other => return Err(KeystoreError::UnsupportedKdf(other.to_string())),
+        }
+
+        if self.crypto.cipher.function != CIPHER_AES_128_CTR {
+            return Err(KeystoreError::UnsupportedCipher(self.crypto.cipher.function.clone()));
+        }
+
+        if self.crypto.checksum.function != CHECKSUM_SHA256 {
+            return Err(KeystoreError::UnsupportedChecksum(self.crypto.checksum.function.clone()));
+        }
+
+        Ok(())
+    }
+
+    pub fn decrypt(&self, password: &[u8]) -> Result<SecretKey, KeystoreError> {
+        let derived_key = self.derive_key(password)?;
+        let ciphertext = hex::decode(&self.crypto.cipher.message)?;
+        self.verify_checksum(&derived_key, &ciphertext)?;
+        let plaintext = self.decrypt_ciphertext(&derived_key, &ciphertext)?;
+        SecretKey::from_bytes(&plaintext).map_err(KeystoreError::from)
+    }
+
+    fn derive_key(&self, password: &[u8]) -> Result<[u8; DERIVED_KEY_LEN], KeystoreError> {
+        match self.crypto.kdf.function.as_str() {
+            KDF_SCRYPT => self.derive_key_scrypt(password),
+            KDF_PBKDF2 => self.derive_key_pbkdf2(password),
+            other => Err(KeystoreError::UnsupportedKdf(other.to_string())),
+        }
+    }
+
+    fn derive_key_scrypt(&self, password: &[u8]) -> Result<[u8; DERIVED_KEY_LEN], KeystoreError> {
+        let params = match &self.crypto.kdf.params {
+            KdfParams::Scrypt(p) => p,
+            _ => {
+                return Err(KeystoreError::InvalidScryptParams(
+                    "expected scrypt params".to_string(),
+                ))
+            }
+        };
+
+        let salt = hex::decode(&params.salt)?;
+        let log_n = (params.n as f64).log2() as u8;
+
+        let scrypt_params = scrypt::Params::new(log_n, params.r, params.p, params.dklen as usize)
+            .map_err(|e| KeystoreError::InvalidScryptParams(e.to_string()))?;
+
+        let mut derived_key = [0u8; DERIVED_KEY_LEN];
+        scrypt::scrypt(password, &salt, &scrypt_params, &mut derived_key)
+            .map_err(|e| KeystoreError::KeyDerivationFailed(e.to_string()))?;
+
+        Ok(derived_key)
+    }
+
+    fn derive_key_pbkdf2(&self, password: &[u8]) -> Result<[u8; DERIVED_KEY_LEN], KeystoreError> {
+        let params = match &self.crypto.kdf.params {
+            KdfParams::Pbkdf2(p) => p,
+            _ => {
+                return Err(KeystoreError::KeyDerivationFailed(
+                    "expected pbkdf2 params".to_string(),
+                ))
+            }
+        };
+
+        if params.prf != "hmac-sha256" {
+            return Err(KeystoreError::KeyDerivationFailed(format!(
+                "unsupported PRF: {}",
+                params.prf
+            )));
+        }
+
+        let salt = hex::decode(&params.salt)?;
+        let mut derived_key = [0u8; DERIVED_KEY_LEN];
+
+        pbkdf2::pbkdf2_hmac::<Sha256>(password, &salt, params.c, &mut derived_key);
+
+        Ok(derived_key)
+    }
+
+    fn verify_checksum(
+        &self,
+        derived_key: &[u8; DERIVED_KEY_LEN],
+        ciphertext: &[u8],
+    ) -> Result<(), KeystoreError> {
+        let expected_checksum = hex::decode(&self.crypto.checksum.message)?;
+
+        let mut hasher = Sha256::new();
+        hasher.update(&derived_key[AES_KEY_LEN..DERIVED_KEY_LEN]);
+        hasher.update(ciphertext);
+        let computed_checksum = hasher.finalize();
+
+        if computed_checksum.as_slice() != expected_checksum {
+            return Err(KeystoreError::ChecksumMismatch);
+        }
+
+        Ok(())
+    }
+
+    fn decrypt_ciphertext(
+        &self,
+        derived_key: &[u8; DERIVED_KEY_LEN],
+        ciphertext: &[u8],
+    ) -> Result<Vec<u8>, KeystoreError> {
+        let iv = hex::decode(&self.crypto.cipher.params.iv)?;
+        let aes_key = &derived_key[..AES_KEY_LEN];
+
+        let mut cipher = Aes128Ctr::new(aes_key.into(), iv.as_slice().into());
+        let mut plaintext = ciphertext.to_vec();
+        cipher.apply_keystream(&mut plaintext);
+
+        Ok(plaintext)
+    }
+
+    pub fn pubkey_bytes(&self) -> Result<Option<Vec<u8>>, KeystoreError> {
+        match &self.pubkey {
+            Some(pk) => Ok(Some(hex::decode(pk)?)),
+            None => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // EIP-2335 official test vectors from https://eips.ethereum.org/EIPS/eip-2335
+    // Password: 0x7465737470617373776f7264f09f9491 (UTF-8: test password with emoji)
+    // Secret: 0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
+    const EIP2335_PASSWORD: &[u8] = &[
+        0x74, 0x65, 0x73, 0x74, 0x70, 0x61, 0x73, 0x73, 0x77, 0x6f, 0x72, 0x64, 0xf0, 0x9f, 0x94,
+        0x91,
+    ];
+    const EIP2335_SECRET_HEX: &str =
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+
+    const EIP2335_SCRYPT_TEST_VECTOR: &str = r#"
+    {
+        "crypto": {
+            "kdf": {
+                "function": "scrypt",
+                "params": {
+                    "dklen": 32,
+                    "n": 262144,
+                    "p": 1,
+                    "r": 8,
+                    "salt": "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
+                },
+                "message": ""
+            },
+            "checksum": {
+                "function": "sha256",
+                "params": {},
+                "message": "d2217fe5f3e9a1e34581ef8a78f7c9928e436d36dacc5e846690a5581e8ea484"
+            },
+            "cipher": {
+                "function": "aes-128-ctr",
+                "params": {
+                    "iv": "264daa3f303d7259501c93d997d84fe6"
+                },
+                "message": "06ae90d55fe0a6e9c5c3bc5b170827b2e5cce3929ed3f116c2811e6366dfe20f"
+            }
+        },
+        "description": "This is a test keystore that uses scrypt to secure the secret.",
+        "pubkey": "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07",
+        "path": "m/12381/60/3141592653/589793238",
+        "uuid": "1d85ae20-35c5-4611-98e8-aa14a633906f",
+        "version": 4
+    }
+    "#;
+
+    const EIP2335_PBKDF2_TEST_VECTOR: &str = r#"
+    {
+        "crypto": {
+            "kdf": {
+                "function": "pbkdf2",
+                "params": {
+                    "dklen": 32,
+                    "c": 262144,
+                    "prf": "hmac-sha256",
+                    "salt": "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
+                },
+                "message": ""
+            },
+            "checksum": {
+                "function": "sha256",
+                "params": {},
+                "message": "8a9f5d9912ed7e75ea794bc5a89bca5f193721d30868ade6f73043c6ea6febf1"
+            },
+            "cipher": {
+                "function": "aes-128-ctr",
+                "params": {
+                    "iv": "264daa3f303d7259501c93d997d84fe6"
+                },
+                "message": "cee03fde2af33149775b7223e7845e4fb2c8ae1792e5f99fe9ecf474cc8c16ad"
+            }
+        },
+        "description": "This is a test keystore that uses PBKDF2 to secure the secret.",
+        "pubkey": "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07",
+        "path": "m/12381/60/0/0",
+        "uuid": "64625def-3331-4eea-ab6f-782f3ed16a83",
+        "version": 4
+    }
+    "#;
+
+    #[test]
+    fn test_parse_scrypt_keystore() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        assert_eq!(keystore.version, 4);
+        assert_eq!(keystore.crypto.kdf.function, "scrypt");
+        assert_eq!(keystore.crypto.cipher.function, "aes-128-ctr");
+        assert_eq!(keystore.crypto.checksum.function, "sha256");
+        assert_eq!(keystore.path, "m/12381/60/3141592653/589793238");
+    }
+
+    #[test]
+    fn test_parse_pbkdf2_keystore() {
+        let keystore = Keystore::from_json(EIP2335_PBKDF2_TEST_VECTOR).expect("should parse");
+        assert_eq!(keystore.version, 4);
+        assert_eq!(keystore.crypto.kdf.function, "pbkdf2");
+        assert_eq!(keystore.crypto.cipher.function, "aes-128-ctr");
+        assert_eq!(keystore.crypto.checksum.function, "sha256");
+        assert_eq!(keystore.path, "m/12381/60/0/0");
+    }
+
+    #[test]
+    fn test_scrypt_params_extraction() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        match &keystore.crypto.kdf.params {
+            KdfParams::Scrypt(params) => {
+                assert_eq!(params.dklen, 32);
+                assert_eq!(params.n, 262144);
+                assert_eq!(params.p, 1);
+                assert_eq!(params.r, 8);
+            }
+            _ => panic!("expected scrypt params"),
+        }
+    }
+
+    #[test]
+    fn test_pbkdf2_params_extraction() {
+        let keystore = Keystore::from_json(EIP2335_PBKDF2_TEST_VECTOR).expect("should parse");
+        match &keystore.crypto.kdf.params {
+            KdfParams::Pbkdf2(params) => {
+                assert_eq!(params.dklen, 32);
+                assert_eq!(params.c, 262144);
+                assert_eq!(params.prf, "hmac-sha256");
+            }
+            _ => panic!("expected pbkdf2 params"),
+        }
+    }
+
+    #[test]
+    fn test_unsupported_version() {
+        let json = r#"
+        {
+            "crypto": {
+                "kdf": { "function": "scrypt", "params": { "dklen": 32, "n": 262144, "p": 1, "r": 8, "salt": "aa" }, "message": "" },
+                "checksum": { "function": "sha256", "params": {}, "message": "aa" },
+                "cipher": { "function": "aes-128-ctr", "params": { "iv": "aa" }, "message": "aa" }
+            },
+            "path": "",
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "version": 3
+        }
+        "#;
+        let result = Keystore::from_json(json);
+        assert!(matches!(result, Err(KeystoreError::UnsupportedVersion(3))));
+    }
+
+    #[test]
+    fn test_unsupported_kdf() {
+        let json = r#"
+        {
+            "crypto": {
+                "kdf": { "function": "argon2id", "params": { "dklen": 32, "n": 262144, "p": 1, "r": 8, "salt": "aa" }, "message": "" },
+                "checksum": { "function": "sha256", "params": {}, "message": "aa" },
+                "cipher": { "function": "aes-128-ctr", "params": { "iv": "aa" }, "message": "aa" }
+            },
+            "path": "",
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "version": 4
+        }
+        "#;
+        let result = Keystore::from_json(json);
+        assert!(matches!(result, Err(KeystoreError::UnsupportedKdf(_))));
+    }
+
+    #[test]
+    fn test_unsupported_cipher() {
+        let json = r#"
+        {
+            "crypto": {
+                "kdf": { "function": "scrypt", "params": { "dklen": 32, "n": 262144, "p": 1, "r": 8, "salt": "aa" }, "message": "" },
+                "checksum": { "function": "sha256", "params": {}, "message": "aa" },
+                "cipher": { "function": "aes-256-gcm", "params": { "iv": "aa" }, "message": "aa" }
+            },
+            "path": "",
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "version": 4
+        }
+        "#;
+        let result = Keystore::from_json(json);
+        assert!(matches!(result, Err(KeystoreError::UnsupportedCipher(_))));
+    }
+
+    #[test]
+    fn test_unsupported_checksum() {
+        let json = r#"
+        {
+            "crypto": {
+                "kdf": { "function": "scrypt", "params": { "dklen": 32, "n": 262144, "p": 1, "r": 8, "salt": "aa" }, "message": "" },
+                "checksum": { "function": "sha512", "params": {}, "message": "aa" },
+                "cipher": { "function": "aes-128-ctr", "params": { "iv": "aa" }, "message": "aa" }
+            },
+            "path": "",
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "version": 4
+        }
+        "#;
+        let result = Keystore::from_json(json);
+        assert!(matches!(result, Err(KeystoreError::UnsupportedChecksum(_))));
+    }
+
+    #[test]
+    fn test_uuid_parsing() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        assert_eq!(keystore.uuid.to_string(), "1d85ae20-35c5-4611-98e8-aa14a633906f");
+    }
+
+    #[test]
+    fn test_pubkey_extraction() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        let pubkey_bytes = keystore.pubkey_bytes().expect("should decode").unwrap();
+        assert_eq!(pubkey_bytes.len(), 48);
+    }
+
+    #[test]
+    fn test_optional_fields() {
+        let json = r#"
+        {
+            "crypto": {
+                "kdf": { "function": "scrypt", "params": { "dklen": 32, "n": 262144, "p": 1, "r": 8, "salt": "aa" }, "message": "" },
+                "checksum": { "function": "sha256", "params": {}, "message": "aa" },
+                "cipher": { "function": "aes-128-ctr", "params": { "iv": "aa" }, "message": "aa" }
+            },
+            "path": "m/12381/60/0/0",
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "version": 4
+        }
+        "#;
+        let keystore = Keystore::from_json(json).expect("should parse");
+        assert!(keystore.description.is_none());
+        assert!(keystore.pubkey.is_none());
+    }
+
+    #[test]
+    fn test_scrypt_key_derivation() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        let derived_key = keystore.derive_key(EIP2335_PASSWORD).expect("should derive key");
+        assert_eq!(derived_key.len(), 32);
+    }
+
+    #[test]
+    fn test_pbkdf2_key_derivation() {
+        let keystore = Keystore::from_json(EIP2335_PBKDF2_TEST_VECTOR).expect("should parse");
+        let derived_key = keystore.derive_key(EIP2335_PASSWORD).expect("should derive key");
+        assert_eq!(derived_key.len(), 32);
+    }
+
+    #[test]
+    fn test_scrypt_decrypt_eip2335_test_vector() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        let secret_key = keystore.decrypt(EIP2335_PASSWORD).expect("should decrypt");
+        let expected_secret = hex::decode(EIP2335_SECRET_HEX).expect("valid hex");
+        assert_eq!(secret_key.to_bytes().to_vec(), expected_secret);
+    }
+
+    #[test]
+    fn test_pbkdf2_decrypt_eip2335_test_vector() {
+        let keystore = Keystore::from_json(EIP2335_PBKDF2_TEST_VECTOR).expect("should parse");
+        let secret_key = keystore.decrypt(EIP2335_PASSWORD).expect("should decrypt");
+        let expected_secret = hex::decode(EIP2335_SECRET_HEX).expect("valid hex");
+        assert_eq!(secret_key.to_bytes().to_vec(), expected_secret);
+    }
+
+    #[test]
+    fn test_checksum_verification_failure_wrong_password() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        let wrong_password = "wrongpassword".as_bytes();
+        let result = keystore.decrypt(wrong_password);
+        assert!(matches!(result, Err(KeystoreError::ChecksumMismatch)));
+    }
+
+    #[test]
+    fn test_checksum_verification_failure_empty_password() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        let result = keystore.decrypt(&[]);
+        assert!(matches!(result, Err(KeystoreError::ChecksumMismatch)));
+    }
+
+    #[test]
+    fn test_serialize_keystore() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        let serialized = serde_json::to_string(&keystore).expect("should serialize");
+        let reparsed: Keystore = serde_json::from_str(&serialized).expect("should reparse");
+        assert_eq!(reparsed.version, keystore.version);
+        assert_eq!(reparsed.uuid, keystore.uuid);
+    }
+
+    #[test]
+    fn test_invalid_json() {
+        let result = Keystore::from_json("not valid json");
+        assert!(matches!(result, Err(KeystoreError::InvalidJson(_))));
+    }
+
+    #[test]
+    fn test_invalid_hex_in_salt() {
+        let json = r#"
+        {
+            "crypto": {
+                "kdf": { "function": "scrypt", "params": { "dklen": 32, "n": 262144, "p": 1, "r": 8, "salt": "not_hex!" }, "message": "" },
+                "checksum": { "function": "sha256", "params": {}, "message": "aa" },
+                "cipher": { "function": "aes-128-ctr", "params": { "iv": "aa" }, "message": "aa" }
+            },
+            "path": "m/12381/60/0/0",
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "version": 4
+        }
+        "#;
+        let keystore = Keystore::from_json(json).expect("should parse json");
+        let result = keystore.decrypt(b"test");
+        assert!(matches!(result, Err(KeystoreError::InvalidHex(_))));
+    }
+
+    #[test]
+    fn test_decrypted_key_can_sign() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        let secret_key = keystore.decrypt(EIP2335_PASSWORD).expect("should decrypt");
+        let message = b"test message";
+        let signature = secret_key.sign(message);
+        let public_key = secret_key.public_key();
+        assert!(signature.verify(&public_key, message).is_ok());
+    }
+}

--- a/crates/rvc/src/crypto/keystore.rs
+++ b/crates/rvc/src/crypto/keystore.rs
@@ -530,6 +530,7 @@ mod tests {
         assert!(matches!(result, Err(KeystoreError::InvalidJson(_))));
     }
 
+    // Scrypt parameter validation tests
     #[test]
     fn test_scrypt_n_zero_returns_error() {
         let json = r#"
@@ -592,6 +593,19 @@ mod tests {
         }
         let result = keystore.decrypt(EIP2335_PASSWORD);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_scrypt_n_large_power_of_two_validation() {
+        // Test that large power-of-2 values pass our validation
+        // (the scrypt library may still reject due to memory limits)
+        let n_values: Vec<u32> = vec![1 << 20, 1 << 24, 1 << 30];
+        for n in n_values {
+            assert!(n.is_power_of_two());
+            assert!(n != 0);
+            // trailing_zeros correctly computes log2 for powers of 2
+            assert_eq!(n.trailing_zeros(), (n as f64).log2() as u32);
+        }
     }
 
     #[test]

--- a/crates/rvc/src/crypto/keystore.rs
+++ b/crates/rvc/src/crypto/keystore.rs
@@ -150,8 +150,14 @@ impl Keystore {
             }
         };
 
+        if params.n == 0 || !params.n.is_power_of_two() {
+            return Err(KeystoreError::InvalidScryptParams(
+                "n must be a positive power of 2".to_string(),
+            ));
+        }
+
         let salt = hex::decode(&params.salt)?;
-        let log_n = (params.n as f64).log2() as u8;
+        let log_n = params.n.trailing_zeros() as u8;
 
         let scrypt_params = scrypt::Params::new(log_n, params.r, params.p, params.dklen as usize)
             .map_err(|e| KeystoreError::InvalidScryptParams(e.to_string()))?;
@@ -522,6 +528,70 @@ mod tests {
     fn test_invalid_json() {
         let result = Keystore::from_json("not valid json");
         assert!(matches!(result, Err(KeystoreError::InvalidJson(_))));
+    }
+
+    #[test]
+    fn test_scrypt_n_zero_returns_error() {
+        let json = r#"
+        {
+            "crypto": {
+                "kdf": {
+                    "function": "scrypt",
+                    "params": { "dklen": 32, "n": 0, "p": 1, "r": 8, "salt": "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" },
+                    "message": ""
+                },
+                "checksum": { "function": "sha256", "params": {}, "message": "d2217fe5f3e9a1e34581ef8a78f7c9928e436d36dacc5e846690a5581e8ea484" },
+                "cipher": { "function": "aes-128-ctr", "params": { "iv": "264daa3f303d7259501c93d997d84fe6" }, "message": "06ae90d55fe0a6e9c5c3bc5b170827b2e5cce3929ed3f116c2811e6366dfe20f" }
+            },
+            "path": "m/12381/60/0/0",
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "version": 4
+        }
+        "#;
+        let keystore = Keystore::from_json(json).expect("should parse json");
+        let result = keystore.decrypt(b"test");
+        assert!(
+            matches!(result, Err(KeystoreError::InvalidScryptParams(msg)) if msg.contains("power of 2"))
+        );
+    }
+
+    #[test]
+    fn test_scrypt_n_not_power_of_two_returns_error() {
+        let json = r#"
+        {
+            "crypto": {
+                "kdf": {
+                    "function": "scrypt",
+                    "params": { "dklen": 32, "n": 3, "p": 1, "r": 8, "salt": "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" },
+                    "message": ""
+                },
+                "checksum": { "function": "sha256", "params": {}, "message": "d2217fe5f3e9a1e34581ef8a78f7c9928e436d36dacc5e846690a5581e8ea484" },
+                "cipher": { "function": "aes-128-ctr", "params": { "iv": "264daa3f303d7259501c93d997d84fe6" }, "message": "06ae90d55fe0a6e9c5c3bc5b170827b2e5cce3929ed3f116c2811e6366dfe20f" }
+            },
+            "path": "m/12381/60/0/0",
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "version": 4
+        }
+        "#;
+        let keystore = Keystore::from_json(json).expect("should parse json");
+        let result = keystore.decrypt(b"test");
+        assert!(
+            matches!(result, Err(KeystoreError::InvalidScryptParams(msg)) if msg.contains("power of 2"))
+        );
+    }
+
+    #[test]
+    fn test_scrypt_n_valid_power_of_two() {
+        let keystore = Keystore::from_json(EIP2335_SCRYPT_TEST_VECTOR).expect("should parse");
+        match &keystore.crypto.kdf.params {
+            KdfParams::Scrypt(params) => {
+                assert_eq!(params.n, 262144);
+                assert!(params.n.is_power_of_two());
+            }
+            _ => panic!("expected scrypt params"),
+        }
+        let result = keystore.decrypt(EIP2335_PASSWORD);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/crates/rvc/src/crypto/mod.rs
+++ b/crates/rvc/src/crypto/mod.rs
@@ -1,0 +1,8 @@
+mod bls;
+mod error;
+
+pub use bls::{
+    PublicKey, SecretKey, Signature, PUBLIC_KEY_BYTES_LEN, SECRET_KEY_BYTES_LEN,
+    SIGNATURE_BYTES_LEN,
+};
+pub use error::BlsError;

--- a/crates/rvc/src/crypto/mod.rs
+++ b/crates/rvc/src/crypto/mod.rs
@@ -1,5 +1,6 @@
 mod bls;
 mod error;
+mod keystore;
 mod signing;
 mod types;
 
@@ -7,7 +8,8 @@ pub use bls::{
     PublicKey, SecretKey, Signature, PUBLIC_KEY_BYTES_LEN, SECRET_KEY_BYTES_LEN,
     SIGNATURE_BYTES_LEN,
 };
-pub use error::BlsError;
+pub use error::{BlsError, KeystoreError};
+pub use keystore::{KdfParams, Keystore, Pbkdf2Params, ScryptParams};
 pub use signing::{
     compute_domain, compute_fork_data_root, compute_signing_root, sign_attestation,
     DOMAIN_BEACON_ATTESTER,

--- a/crates/rvc/src/crypto/mod.rs
+++ b/crates/rvc/src/crypto/mod.rs
@@ -1,5 +1,6 @@
 mod bls;
 mod error;
+mod key_manager;
 mod keystore;
 mod signing;
 mod types;
@@ -8,7 +9,8 @@ pub use bls::{
     PublicKey, SecretKey, Signature, PUBLIC_KEY_BYTES_LEN, SECRET_KEY_BYTES_LEN,
     SIGNATURE_BYTES_LEN,
 };
-pub use error::{BlsError, KeystoreError};
+pub use error::{BlsError, KeyManagerError, KeystoreError};
+pub use key_manager::KeyManager;
 pub use keystore::{KdfParams, Keystore, Pbkdf2Params, ScryptParams};
 pub use signing::{
     compute_domain, compute_fork_data_root, compute_signing_root, sign_attestation,

--- a/crates/rvc/src/crypto/mod.rs
+++ b/crates/rvc/src/crypto/mod.rs
@@ -1,8 +1,18 @@
 mod bls;
 mod error;
+mod signing;
+mod types;
 
 pub use bls::{
     PublicKey, SecretKey, Signature, PUBLIC_KEY_BYTES_LEN, SECRET_KEY_BYTES_LEN,
     SIGNATURE_BYTES_LEN,
 };
 pub use error::BlsError;
+pub use signing::{
+    compute_domain, compute_fork_data_root, compute_signing_root, sign_attestation,
+    DOMAIN_BEACON_ATTESTER,
+};
+pub use types::{
+    AttestationData, Checkpoint, CommitteeIndex, Domain, DomainType, Epoch, Fork, ForkData, Root,
+    SigningData, Slot, Version,
+};

--- a/crates/rvc/src/crypto/signing.rs
+++ b/crates/rvc/src/crypto/signing.rs
@@ -1,0 +1,291 @@
+use ssz::Encode;
+
+use super::bls::{SecretKey, Signature};
+use super::types::{AttestationData, Domain, DomainType, Fork, ForkData, Root, SigningData};
+
+pub const DOMAIN_BEACON_ATTESTER: DomainType = [0x01, 0x00, 0x00, 0x00];
+
+fn hash(data: &[u8]) -> Root {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    let result = hasher.finalize();
+    let mut root = [0u8; 32];
+    root.copy_from_slice(&result);
+    root
+}
+
+fn hash_tree_root<T: Encode>(object: &T) -> Root {
+    let encoded = object.as_ssz_bytes();
+    let chunks = pad_to_chunks(&encoded);
+    merkleize(&chunks)
+}
+
+fn pad_to_chunks(data: &[u8]) -> Vec<[u8; 32]> {
+    let num_chunks = data.len().div_ceil(32);
+    let mut chunks = Vec::with_capacity(num_chunks.max(1));
+
+    for i in 0..num_chunks {
+        let mut chunk = [0u8; 32];
+        let start = i * 32;
+        let end = (start + 32).min(data.len());
+        chunk[..end - start].copy_from_slice(&data[start..end]);
+        chunks.push(chunk);
+    }
+
+    if chunks.is_empty() {
+        chunks.push([0u8; 32]);
+    }
+
+    chunks
+}
+
+fn merkleize(chunks: &[[u8; 32]]) -> Root {
+    if chunks.is_empty() {
+        return [0u8; 32];
+    }
+
+    if chunks.len() == 1 {
+        return chunks[0];
+    }
+
+    let next_power_of_two = chunks.len().next_power_of_two();
+    let mut layer: Vec<[u8; 32]> = chunks.to_vec();
+    layer.resize(next_power_of_two, [0u8; 32]);
+
+    while layer.len() > 1 {
+        let mut next_layer = Vec::with_capacity(layer.len() / 2);
+        for i in (0..layer.len()).step_by(2) {
+            let mut combined = [0u8; 64];
+            combined[..32].copy_from_slice(&layer[i]);
+            combined[32..].copy_from_slice(&layer[i + 1]);
+            next_layer.push(hash(&combined));
+        }
+        layer = next_layer;
+    }
+
+    layer[0]
+}
+
+pub fn compute_fork_data_root(current_version: [u8; 4], genesis_validators_root: Root) -> Root {
+    let fork_data = ForkData { current_version, genesis_validators_root };
+    hash_tree_root(&fork_data)
+}
+
+pub fn compute_domain(
+    domain_type: DomainType,
+    fork_version: [u8; 4],
+    genesis_validators_root: Root,
+) -> Domain {
+    let fork_data_root = compute_fork_data_root(fork_version, genesis_validators_root);
+    let mut domain = [0u8; 32];
+    domain[..4].copy_from_slice(&domain_type);
+    domain[4..32].copy_from_slice(&fork_data_root[..28]);
+    domain
+}
+
+pub fn compute_signing_root<T: Encode>(ssz_object: &T, domain: Domain) -> Root {
+    let object_root = hash_tree_root(ssz_object);
+    let signing_data = SigningData { object_root, domain };
+    hash_tree_root(&signing_data)
+}
+
+pub fn sign_attestation(
+    attestation_data: &AttestationData,
+    secret_key: &SecretKey,
+    fork: &Fork,
+    genesis_validators_root: Root,
+) -> Signature {
+    let fork_version = if attestation_data.target.epoch >= fork.epoch {
+        fork.current_version
+    } else {
+        fork.previous_version
+    };
+
+    let domain = compute_domain(DOMAIN_BEACON_ATTESTER, fork_version, genesis_validators_root);
+
+    let signing_root = compute_signing_root(attestation_data, domain);
+    secret_key.sign(&signing_root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::types::Checkpoint;
+
+    #[test]
+    fn test_domain_beacon_attester_value() {
+        assert_eq!(DOMAIN_BEACON_ATTESTER, [0x01, 0x00, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn test_compute_fork_data_root_deterministic() {
+        let version = [0x00, 0x00, 0x00, 0x01];
+        let genesis_root = [0xab; 32];
+
+        let root1 = compute_fork_data_root(version, genesis_root);
+        let root2 = compute_fork_data_root(version, genesis_root);
+
+        assert_eq!(root1, root2);
+    }
+
+    #[test]
+    fn test_compute_fork_data_root_different_inputs_different_outputs() {
+        let version1 = [0x00, 0x00, 0x00, 0x01];
+        let version2 = [0x00, 0x00, 0x00, 0x02];
+        let genesis_root = [0xab; 32];
+
+        let root1 = compute_fork_data_root(version1, genesis_root);
+        let root2 = compute_fork_data_root(version2, genesis_root);
+
+        assert_ne!(root1, root2);
+    }
+
+    #[test]
+    fn test_compute_domain_includes_domain_type() {
+        let domain = compute_domain(DOMAIN_BEACON_ATTESTER, [0x00, 0x00, 0x00, 0x01], [0x00; 32]);
+
+        assert_eq!(&domain[..4], &DOMAIN_BEACON_ATTESTER);
+    }
+
+    #[test]
+    fn test_compute_domain_different_fork_versions() {
+        let genesis_root = [0x00; 32];
+
+        let domain1 =
+            compute_domain(DOMAIN_BEACON_ATTESTER, [0x00, 0x00, 0x00, 0x01], genesis_root);
+        let domain2 =
+            compute_domain(DOMAIN_BEACON_ATTESTER, [0x00, 0x00, 0x00, 0x02], genesis_root);
+
+        assert_ne!(domain1, domain2);
+        assert_eq!(&domain1[..4], &domain2[..4]);
+    }
+
+    #[test]
+    fn test_compute_signing_root_deterministic() {
+        let data = create_test_attestation_data();
+        let domain = [0x01; 32];
+
+        let root1 = compute_signing_root(&data, domain);
+        let root2 = compute_signing_root(&data, domain);
+
+        assert_eq!(root1, root2);
+    }
+
+    #[test]
+    fn test_compute_signing_root_different_domains() {
+        let data = create_test_attestation_data();
+
+        let root1 = compute_signing_root(&data, [0x01; 32]);
+        let root2 = compute_signing_root(&data, [0x02; 32]);
+
+        assert_ne!(root1, root2);
+    }
+
+    #[test]
+    fn test_sign_attestation_produces_valid_signature() {
+        let secret_key = SecretKey::generate();
+        let public_key = secret_key.public_key();
+        let attestation_data = create_test_attestation_data();
+        let fork = create_test_fork();
+        let genesis_root = [0xaa; 32];
+
+        let signature = sign_attestation(&attestation_data, &secret_key, &fork, genesis_root);
+
+        let fork_version = fork.current_version;
+        let domain = compute_domain(DOMAIN_BEACON_ATTESTER, fork_version, genesis_root);
+        let signing_root = compute_signing_root(&attestation_data, domain);
+
+        assert!(signature.verify(&public_key, &signing_root).is_ok());
+    }
+
+    #[test]
+    fn test_sign_attestation_uses_previous_version_for_old_epoch() {
+        let secret_key = SecretKey::generate();
+        let public_key = secret_key.public_key();
+        let genesis_root = [0xaa; 32];
+
+        let fork = Fork {
+            previous_version: [0x00, 0x00, 0x00, 0x01],
+            current_version: [0x00, 0x00, 0x00, 0x02],
+            epoch: 100,
+        };
+
+        let attestation_data = AttestationData {
+            slot: 1000,
+            index: 1,
+            beacon_block_root: [0x11; 32],
+            source: Checkpoint { epoch: 50, root: [0x22; 32] },
+            target: Checkpoint { epoch: 51, root: [0x33; 32] },
+        };
+
+        let signature = sign_attestation(&attestation_data, &secret_key, &fork, genesis_root);
+
+        let domain = compute_domain(DOMAIN_BEACON_ATTESTER, fork.previous_version, genesis_root);
+        let signing_root = compute_signing_root(&attestation_data, domain);
+
+        assert!(signature.verify(&public_key, &signing_root).is_ok());
+    }
+
+    #[test]
+    fn test_sign_attestation_uses_current_version_for_current_epoch() {
+        let secret_key = SecretKey::generate();
+        let public_key = secret_key.public_key();
+        let genesis_root = [0xaa; 32];
+
+        let fork = Fork {
+            previous_version: [0x00, 0x00, 0x00, 0x01],
+            current_version: [0x00, 0x00, 0x00, 0x02],
+            epoch: 100,
+        };
+
+        let attestation_data = AttestationData {
+            slot: 5000,
+            index: 1,
+            beacon_block_root: [0x11; 32],
+            source: Checkpoint { epoch: 150, root: [0x22; 32] },
+            target: Checkpoint { epoch: 151, root: [0x33; 32] },
+        };
+
+        let signature = sign_attestation(&attestation_data, &secret_key, &fork, genesis_root);
+
+        let domain = compute_domain(DOMAIN_BEACON_ATTESTER, fork.current_version, genesis_root);
+        let signing_root = compute_signing_root(&attestation_data, domain);
+
+        assert!(signature.verify(&public_key, &signing_root).is_ok());
+    }
+
+    #[test]
+    fn test_different_attestation_data_produces_different_signatures() {
+        let secret_key = SecretKey::generate();
+        let fork = create_test_fork();
+        let genesis_root = [0xaa; 32];
+
+        let data1 = create_test_attestation_data();
+        let mut data2 = create_test_attestation_data();
+        data2.slot = 2000;
+
+        let sig1 = sign_attestation(&data1, &secret_key, &fork, genesis_root);
+        let sig2 = sign_attestation(&data2, &secret_key, &fork, genesis_root);
+
+        assert_ne!(sig1.to_bytes(), sig2.to_bytes());
+    }
+
+    fn create_test_attestation_data() -> AttestationData {
+        AttestationData {
+            slot: 1000,
+            index: 5,
+            beacon_block_root: [0x11; 32],
+            source: Checkpoint { epoch: 99, root: [0x22; 32] },
+            target: Checkpoint { epoch: 100, root: [0x33; 32] },
+        }
+    }
+
+    fn create_test_fork() -> Fork {
+        Fork {
+            previous_version: [0x00, 0x00, 0x00, 0x01],
+            current_version: [0x00, 0x00, 0x00, 0x02],
+            epoch: 50,
+        }
+    }
+}

--- a/crates/rvc/src/crypto/types.rs
+++ b/crates/rvc/src/crypto/types.rs
@@ -1,0 +1,92 @@
+use ssz_derive::{Decode, Encode};
+
+pub type Slot = u64;
+pub type Epoch = u64;
+pub type CommitteeIndex = u64;
+pub type Version = [u8; 4];
+pub type Root = [u8; 32];
+pub type Domain = [u8; 32];
+pub type DomainType = [u8; 4];
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct Checkpoint {
+    pub epoch: Epoch,
+    pub root: Root,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct AttestationData {
+    pub slot: Slot,
+    pub index: CommitteeIndex,
+    pub beacon_block_root: Root,
+    pub source: Checkpoint,
+    pub target: Checkpoint,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct Fork {
+    pub previous_version: Version,
+    pub current_version: Version,
+    pub epoch: Epoch,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct ForkData {
+    pub current_version: Version,
+    pub genesis_validators_root: Root,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct SigningData {
+    pub object_root: Root,
+    pub domain: Domain,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ssz::Encode;
+
+    #[test]
+    fn test_checkpoint_ssz_encode() {
+        let checkpoint = Checkpoint { epoch: 100, root: [0u8; 32] };
+        let encoded = checkpoint.as_ssz_bytes();
+        assert_eq!(encoded.len(), 8 + 32);
+    }
+
+    #[test]
+    fn test_attestation_data_ssz_encode() {
+        let data = AttestationData {
+            slot: 1000,
+            index: 5,
+            beacon_block_root: [1u8; 32],
+            source: Checkpoint { epoch: 99, root: [2u8; 32] },
+            target: Checkpoint { epoch: 100, root: [3u8; 32] },
+        };
+        let encoded = data.as_ssz_bytes();
+        assert_eq!(encoded.len(), 8 + 8 + 32 + 40 + 40);
+    }
+
+    #[test]
+    fn test_fork_ssz_encode() {
+        let fork =
+            Fork { previous_version: [0, 0, 0, 0], current_version: [1, 0, 0, 0], epoch: 100 };
+        let encoded = fork.as_ssz_bytes();
+        assert_eq!(encoded.len(), 4 + 4 + 8);
+    }
+
+    #[test]
+    fn test_fork_data_ssz_encode() {
+        let fork_data =
+            ForkData { current_version: [1, 0, 0, 0], genesis_validators_root: [0u8; 32] };
+        let encoded = fork_data.as_ssz_bytes();
+        assert_eq!(encoded.len(), 4 + 32);
+    }
+
+    #[test]
+    fn test_signing_data_ssz_encode() {
+        let signing_data = SigningData { object_root: [0u8; 32], domain: [1u8; 32] };
+        let encoded = signing_data.as_ssz_bytes();
+        assert_eq!(encoded.len(), 32 + 32);
+    }
+}

--- a/crates/rvc/src/lib.rs
+++ b/crates/rvc/src/lib.rs
@@ -1,6 +1,7 @@
 //! rvc - Rust Validator Client
 
 pub mod beacon;
+pub mod crypto;
 pub mod duty_tracker;
 
 pub mod proto {


### PR DESCRIPTION
## Summary

- Add explicit validation for scrypt's `n` parameter to reject zero and non-power-of-2 values
- Replace unsafe floating-point `log2()` with integer `trailing_zeros()` for computing log_n
- Add comprehensive test cases for invalid and valid scrypt parameters

## Changes

In `derive_key_scrypt()`:
1. Added validation check: `if params.n == 0 || !params.n.is_power_of_two()`
2. Returns `KeystoreError::InvalidScryptParams("n must be a positive power of 2")` on failure
3. Replaced `(params.n as f64).log2() as u8` with `params.n.trailing_zeros() as u8`

## Test Cases Added

- `test_scrypt_n_zero_returns_error` - Tests that `n = 0` returns `InvalidScryptParams` error
- `test_scrypt_n_not_power_of_two_returns_error` - Tests that `n = 3` returns `InvalidScryptParams` error
- `test_scrypt_n_valid_power_of_two` - Tests that valid `n = 262144` works correctly

## Test Plan

- [x] All new test cases pass
- [x] All existing keystore tests pass (24 tests)
- [x] Full workspace test suite passes (131 tests)
- [x] `cargo fmt` - no formatting issues
- [x] `cargo clippy` - no warnings

close #52

---
Generated with [Claude Code](https://claude.com/claude-code)