### PR TITLE
feat(crypto): use secrecy crate for password memory protection (#55)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,6 +2474,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "scrypt",
+ "secrecy",
  "serde",
  "serde_json",
  "sha2",
@@ -2544,6 +2545,15 @@ dependencies = [
  "generic-array",
  "pkcs8",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ pbkdf2 = "0.12"
 aes = "0.8"
 ctr = "0.9"
 uuid = { version = "1", features = ["v4", "serde"] }
+secrecy = "0.10"
 
 # Dev dependencies
 tempfile = "3"

--- a/crates/rvc/Cargo.toml
+++ b/crates/rvc/Cargo.toml
@@ -27,6 +27,7 @@ pbkdf2.workspace = true
 aes.workspace = true
 ctr.workspace = true
 uuid.workspace = true
+secrecy.workspace = true
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/crates/rvc/src/crypto/key_manager.rs
+++ b/crates/rvc/src/crypto/key_manager.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
+use secrecy::{ExposeSecret, SecretString};
 use tracing::warn;
 
 use super::bls::{PublicKey, SecretKey, PUBLIC_KEY_BYTES_LEN};
@@ -20,12 +21,13 @@ impl KeyManager {
     /// Loads all keystore files from a directory.
     ///
     /// The `passwords` map uses public key hex strings (without 0x prefix) as keys
-    /// and the corresponding password strings as values.
+    /// and `SecretString` values for secure password handling.
     ///
+    /// Passwords are automatically zeroized when the HashMap is dropped.
     /// Corrupted or unreadable keystores are logged and skipped.
     pub fn load_from_directory<P: AsRef<Path>>(
         path: P,
-        passwords: &HashMap<String, String>,
+        passwords: &HashMap<String, SecretString>,
     ) -> Result<Self, KeyManagerError> {
         let dir_path = path.as_ref();
 
@@ -91,7 +93,7 @@ impl KeyManager {
                 }
             };
 
-            let secret_key = match keystore.decrypt(password.as_bytes()) {
+            let secret_key = match keystore.decrypt(password.expose_secret().as_bytes()) {
                 Ok(sk) => sk,
                 Err(e) => {
                     warn!("Failed to decrypt keystore {:?}: {}", file_path, e);
@@ -138,6 +140,7 @@ mod tests {
     use std::fs::File;
     use std::io::Write;
 
+    use secrecy::SecretString;
     use tempfile::TempDir;
 
     use super::*;
@@ -194,6 +197,10 @@ mod tests {
         String::from_utf8(TEST_PASSWORD.to_vec()).unwrap()
     }
 
+    fn test_password_secret() -> SecretString {
+        SecretString::from(test_password_string())
+    }
+
     #[test]
     fn test_new_key_manager_is_empty() {
         let manager = KeyManager::new();
@@ -222,7 +229,7 @@ mod tests {
         create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
 
         let mut passwords = HashMap::new();
-        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_string());
+        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_secret());
 
         let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
         assert_eq!(manager.len(), 1);
@@ -235,7 +242,7 @@ mod tests {
         create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
 
         let mut passwords = HashMap::new();
-        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_string());
+        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_secret());
 
         let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
 
@@ -255,7 +262,7 @@ mod tests {
         create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
 
         let mut passwords = HashMap::new();
-        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_string());
+        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_secret());
 
         let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
 
@@ -271,7 +278,7 @@ mod tests {
         create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
 
         let mut passwords = HashMap::new();
-        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_string());
+        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_secret());
 
         let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
 
@@ -289,7 +296,7 @@ mod tests {
         create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
 
         let mut passwords = HashMap::new();
-        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_string());
+        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_secret());
 
         let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
         assert_eq!(manager.len(), 1);
@@ -301,7 +308,8 @@ mod tests {
         create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
 
         let mut passwords = HashMap::new();
-        passwords.insert(TEST_PUBKEY_HEX.to_string(), "wrong_password".to_string());
+        passwords
+            .insert(TEST_PUBKEY_HEX.to_string(), SecretString::from("wrong_password".to_string()));
 
         let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
         assert!(manager.is_empty());
@@ -325,7 +333,7 @@ mod tests {
         create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
 
         let mut passwords = HashMap::new();
-        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_string());
+        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_secret());
 
         let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
         assert_eq!(manager.len(), 1);
@@ -351,7 +359,7 @@ mod tests {
         create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
 
         let mut passwords = HashMap::new();
-        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_string());
+        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_secret());
 
         let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
         assert_eq!(manager.len(), 1);
@@ -369,7 +377,7 @@ mod tests {
         create_test_keystore_file(&temp_dir, "validator1.json", TEST_KEYSTORE_PBKDF2);
 
         let mut passwords = HashMap::new();
-        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_string());
+        passwords.insert(TEST_PUBKEY_HEX.to_string(), test_password_secret());
 
         let manager = KeyManager::load_from_directory(temp_dir.path(), &passwords).unwrap();
 
@@ -381,5 +389,12 @@ mod tests {
         let signature = secret_key.sign(message);
 
         assert!(signature.verify(&pubkey, message).is_ok());
+    }
+
+    #[test]
+    fn test_secret_string_password_is_not_exposed_in_debug() {
+        let secret = test_password_secret();
+        let debug_output = format!("{:?}", secret);
+        assert!(!debug_output.contains(&test_password_string()));
     }
 }


### PR DESCRIPTION
## Summary

- Add `secrecy` crate (v0.10) for secure password handling
- Update `KeyManager::load_from_directory` to accept `HashMap<String, SecretString>` instead of `HashMap<String, String>`
- Use `ExposeSecret` trait to access password only when needed for decryption
- Passwords are automatically zeroized when the HashMap is dropped

## Security Benefits

- **Memory protection**: Passwords are automatically zeroized on drop, preventing memory inspection attacks
- **Debug safety**: `SecretString` implements `Debug` without revealing contents, preventing accidental logging
- **Explicit access**: Password access is now explicit via `ExposeSecret` trait, making security boundaries clear

## Changes

- `/Cargo.toml`: Add `secrecy = "0.10"` to workspace dependencies
- `/crates/rvc/Cargo.toml`: Add `secrecy.workspace = true`
- `/crates/rvc/src/crypto/key_manager.rs`:
  - Import `secrecy::{ExposeSecret, SecretString}`
  - Update function signature to use `SecretString`
  - Use `password.expose_secret().as_bytes()` for decryption
  - Update all tests to use `SecretString`
  - Add test verifying passwords are not exposed in Debug output

## Test Plan

- [x] All existing key_manager tests updated to use `SecretString`
- [x] Added new test `test_secret_string_password_is_not_exposed_in_debug`
- [x] All 17 tests pass
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt` applied

Closes #55

---
Generated with [Claude Code](https://claude.com/claude-code)