### PR TITLE
feat(slashing): implement SQLite database layer (#23)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,6 +1042,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1319,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1312,6 +1345,15 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1738,6 +1780,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2010,6 +2063,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
@@ -2467,6 +2526,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,6 +2652,7 @@ dependencies = [
  "prost",
  "rand 0.8.5",
  "reqwest",
+ "rusqlite",
  "scrypt",
  "secrecy",
  "serde",
@@ -3415,6 +3489,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ uuid = { version = "1", features = ["v4", "serde"] }
 secrecy = "0.10"
 zeroize = { version = "1.8", features = ["derive"] }
 
+# Database
+rusqlite = { version = "0.32", features = ["bundled"] }
+
 # Dev dependencies
 tempfile = "3"
 wiremock = "0.6"

--- a/crates/rvc/Cargo.toml
+++ b/crates/rvc/Cargo.toml
@@ -33,6 +33,7 @@ prometheus.workspace = true
 lazy_static.workspace = true
 secrecy.workspace = true
 zeroize.workspace = true
+rusqlite.workspace = true
 subtle = "2.6"
 
 [build-dependencies]

--- a/crates/rvc/src/slashing/db.rs
+++ b/crates/rvc/src/slashing/db.rs
@@ -1,0 +1,402 @@
+//! SQLite database layer for slashing protection.
+
+use std::path::Path;
+
+use rusqlite::Connection;
+
+use super::error::SlashingError;
+use super::types::{SignedAttestation, SignedBlock};
+use crate::crypto::Epoch;
+
+/// SQLite-backed database for storing slashing protection data.
+pub struct SlashingDb {
+    conn: Connection,
+}
+
+impl SlashingDb {
+    /// Open a database at the specified path.
+    /// Creates the file and runs migrations if it doesn't exist.
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, SlashingError> {
+        let conn = Connection::open(path)?;
+        let db = Self { conn };
+        db.migrate()?;
+        Ok(db)
+    }
+
+    /// Open an in-memory database for testing.
+    pub fn open_in_memory() -> Result<Self, SlashingError> {
+        let conn = Connection::open_in_memory()?;
+        let db = Self { conn };
+        db.migrate()?;
+        Ok(db)
+    }
+
+    fn migrate(&self) -> Result<(), SlashingError> {
+        self.conn.execute_batch(
+            "
+            CREATE TABLE IF NOT EXISTS attestations (
+                id INTEGER PRIMARY KEY,
+                pubkey TEXT NOT NULL,
+                source_epoch INTEGER NOT NULL,
+                target_epoch INTEGER NOT NULL,
+                signing_root TEXT,
+                UNIQUE(pubkey, target_epoch)
+            );
+
+            CREATE TABLE IF NOT EXISTS blocks (
+                id INTEGER PRIMARY KEY,
+                pubkey TEXT NOT NULL,
+                slot INTEGER NOT NULL,
+                signing_root TEXT,
+                UNIQUE(pubkey, slot)
+            );
+            ",
+        )?;
+        Ok(())
+    }
+
+    /// Insert a signed attestation record.
+    pub fn insert_attestation(&self, attestation: &SignedAttestation) -> Result<(), SlashingError> {
+        self.conn.execute(
+            "INSERT INTO attestations (pubkey, source_epoch, target_epoch, signing_root)
+             VALUES (?1, ?2, ?3, ?4)",
+            (
+                &attestation.pubkey,
+                attestation.source_epoch as i64,
+                attestation.target_epoch as i64,
+                &attestation.signing_root,
+            ),
+        )?;
+        Ok(())
+    }
+
+    /// Get all attestations for a given public key.
+    pub fn get_attestations(&self, pubkey: &str) -> Result<Vec<SignedAttestation>, SlashingError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT pubkey, source_epoch, target_epoch, signing_root
+             FROM attestations
+             WHERE pubkey = ?1
+             ORDER BY target_epoch ASC",
+        )?;
+
+        let rows = stmt.query_map([pubkey], |row| {
+            Ok(SignedAttestation {
+                pubkey: row.get(0)?,
+                source_epoch: row.get::<_, i64>(1)? as Epoch,
+                target_epoch: row.get::<_, i64>(2)? as Epoch,
+                signing_root: row.get(3)?,
+            })
+        })?;
+
+        let mut attestations = Vec::new();
+        for row in rows {
+            attestations.push(row?);
+        }
+        Ok(attestations)
+    }
+
+    /// Insert a signed block record.
+    pub fn insert_block(&self, block: &SignedBlock) -> Result<(), SlashingError> {
+        self.conn.execute(
+            "INSERT INTO blocks (pubkey, slot, signing_root)
+             VALUES (?1, ?2, ?3)",
+            (&block.pubkey, block.slot as i64, &block.signing_root),
+        )?;
+        Ok(())
+    }
+
+    /// Get all blocks for a given public key.
+    pub fn get_blocks(&self, pubkey: &str) -> Result<Vec<SignedBlock>, SlashingError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT pubkey, slot, signing_root
+             FROM blocks
+             WHERE pubkey = ?1
+             ORDER BY slot ASC",
+        )?;
+
+        let rows = stmt.query_map([pubkey], |row| {
+            Ok(SignedBlock {
+                pubkey: row.get(0)?,
+                slot: row.get::<_, i64>(1)? as u64,
+                signing_root: row.get(2)?,
+            })
+        })?;
+
+        let mut blocks = Vec::new();
+        for row in rows {
+            blocks.push(row?);
+        }
+        Ok(blocks)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_open_in_memory_database() {
+        let db = SlashingDb::open_in_memory();
+        assert!(db.is_ok());
+    }
+
+    #[test]
+    fn test_open_file_database() {
+        let dir = tempdir().expect("failed to create temp dir");
+        let path = dir.path().join("test.db");
+
+        let db = SlashingDb::open(&path);
+        assert!(db.is_ok());
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn test_migration_creates_tables() {
+        let db = SlashingDb::open_in_memory().expect("failed to open db");
+
+        let table_count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('attestations', 'blocks')",
+                [],
+                |row| row.get(0),
+            )
+            .expect("failed to query tables");
+
+        assert_eq!(table_count, 2);
+    }
+
+    #[test]
+    fn test_migration_is_idempotent() {
+        let db = SlashingDb::open_in_memory().expect("failed to open db");
+        assert!(db.migrate().is_ok());
+        assert!(db.migrate().is_ok());
+    }
+
+    #[test]
+    fn test_insert_and_get_attestation() {
+        let db = SlashingDb::open_in_memory().expect("failed to open db");
+
+        let attestation = SignedAttestation {
+            pubkey: "0x1234".to_string(),
+            source_epoch: 100,
+            target_epoch: 101,
+            signing_root: Some("0xabcd".to_string()),
+        };
+
+        db.insert_attestation(&attestation).expect("failed to insert");
+
+        let attestations = db.get_attestations("0x1234").expect("failed to get");
+        assert_eq!(attestations.len(), 1);
+        assert_eq!(attestations[0], attestation);
+    }
+
+    #[test]
+    fn test_insert_attestation_without_signing_root() {
+        let db = SlashingDb::open_in_memory().expect("failed to open db");
+
+        let attestation = SignedAttestation {
+            pubkey: "0x1234".to_string(),
+            source_epoch: 100,
+            target_epoch: 101,
+            signing_root: None,
+        };
+
+        db.insert_attestation(&attestation).expect("failed to insert");
+
+        let attestations = db.get_attestations("0x1234").expect("failed to get");
+        assert_eq!(attestations.len(), 1);
+        assert!(attestations[0].signing_root.is_none());
+    }
+
+    #[test]
+    fn test_get_attestations_empty() {
+        let db = SlashingDb::open_in_memory().expect("failed to open db");
+
+        let attestations = db.get_attestations("0xnonexistent").expect("failed to get");
+        assert!(attestations.is_empty());
+    }
+
+    #[test]
+    fn test_get_attestations_multiple() {
+        let db = SlashingDb::open_in_memory().expect("failed to open db");
+
+        let attestations = vec![
+            SignedAttestation {
+                pubkey: "0x1234".to_string(),
+                source_epoch: 100,
+                target_epoch: 101,
+                signing_root: None,
+            },
+            SignedAttestation {
+                pubkey: "0x1234".to_string(),
+                source_epoch: 101,
+                target_epoch: 102,
+                signing_root: None,
+            },
+        ];
+
+        for a in &attestations {
+            db.insert_attestation(a).expect("failed to insert");
+        }
+
+        let result = db.get_attestations("0x1234").expect("failed to get");
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].target_epoch, 101);
+        assert_eq!(result[1].target_epoch, 102);
+    }
+
+    #[test]
+    fn test_attestation_unique_constraint() {
+        let db = SlashingDb::open_in_memory().expect("failed to open db");
+
+        let attestation = SignedAttestation {
+            pubkey: "0x1234".to_string(),
+            source_epoch: 100,
+            target_epoch: 101,
+            signing_root: None,
+        };
+
+        db.insert_attestation(&attestation).expect("first insert should succeed");
+
+        let duplicate = SignedAttestation {
+            pubkey: "0x1234".to_string(),
+            source_epoch: 99,
+            target_epoch: 101,
+            signing_root: Some("0xdifferent".to_string()),
+        };
+
+        let result = db.insert_attestation(&duplicate);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_insert_and_get_block() {
+        let db = SlashingDb::open_in_memory().expect("failed to open db");
+
+        let block = SignedBlock {
+            pubkey: "0x1234".to_string(),
+            slot: 1000,
+            signing_root: Some("0xabcd".to_string()),
+        };
+
+        db.insert_block(&block).expect("failed to insert");
+
+        let blocks = db.get_blocks("0x1234").expect("failed to get");
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0], block);
+    }
+
+    #[test]
+    fn test_insert_block_without_signing_root() {
+        let db = SlashingDb::open_in_memory().expect("failed to open db");
+
+        let block = SignedBlock { pubkey: "0x1234".to_string(), slot: 1000, signing_root: None };
+
+        db.insert_block(&block).expect("failed to insert");
+
+        let blocks = db.get_blocks("0x1234").expect("failed to get");
+        assert_eq!(blocks.len(), 1);
+        assert!(blocks[0].signing_root.is_none());
+    }
+
+    #[test]
+    fn test_get_blocks_empty() {
+        let db = SlashingDb::open_in_memory().expect("failed to open db");
+
+        let blocks = db.get_blocks("0xnonexistent").expect("failed to get");
+        assert!(blocks.is_empty());
+    }
+
+    #[test]
+    fn test_get_blocks_multiple() {
+        let db = SlashingDb::open_in_memory().expect("failed to open db");
+
+        let blocks = vec![
+            SignedBlock { pubkey: "0x1234".to_string(), slot: 1000, signing_root: None },
+            SignedBlock { pubkey: "0x1234".to_string(), slot: 1001, signing_root: None },
+        ];
+
+        for b in &blocks {
+            db.insert_block(b).expect("failed to insert");
+        }
+
+        let result = db.get_blocks("0x1234").expect("failed to get");
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].slot, 1000);
+        assert_eq!(result[1].slot, 1001);
+    }
+
+    #[test]
+    fn test_block_unique_constraint() {
+        let db = SlashingDb::open_in_memory().expect("failed to open db");
+
+        let block = SignedBlock { pubkey: "0x1234".to_string(), slot: 1000, signing_root: None };
+
+        db.insert_block(&block).expect("first insert should succeed");
+
+        let duplicate = SignedBlock {
+            pubkey: "0x1234".to_string(),
+            slot: 1000,
+            signing_root: Some("0xdifferent".to_string()),
+        };
+
+        let result = db.insert_block(&duplicate);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_different_pubkeys_isolated() {
+        let db = SlashingDb::open_in_memory().expect("failed to open db");
+
+        let attestation1 = SignedAttestation {
+            pubkey: "0x1111".to_string(),
+            source_epoch: 100,
+            target_epoch: 101,
+            signing_root: None,
+        };
+
+        let attestation2 = SignedAttestation {
+            pubkey: "0x2222".to_string(),
+            source_epoch: 100,
+            target_epoch: 101,
+            signing_root: None,
+        };
+
+        db.insert_attestation(&attestation1).expect("failed to insert");
+        db.insert_attestation(&attestation2).expect("failed to insert");
+
+        let result1 = db.get_attestations("0x1111").expect("failed to get");
+        let result2 = db.get_attestations("0x2222").expect("failed to get");
+
+        assert_eq!(result1.len(), 1);
+        assert_eq!(result2.len(), 1);
+        assert_eq!(result1[0].pubkey, "0x1111");
+        assert_eq!(result2[0].pubkey, "0x2222");
+    }
+
+    #[test]
+    fn test_persistence_across_connections() {
+        let dir = tempdir().expect("failed to create temp dir");
+        let path = dir.path().join("test.db");
+
+        {
+            let db = SlashingDb::open(&path).expect("failed to open db");
+            let attestation = SignedAttestation {
+                pubkey: "0x1234".to_string(),
+                source_epoch: 100,
+                target_epoch: 101,
+                signing_root: None,
+            };
+            db.insert_attestation(&attestation).expect("failed to insert");
+        }
+
+        {
+            let db = SlashingDb::open(&path).expect("failed to reopen db");
+            let attestations = db.get_attestations("0x1234").expect("failed to get");
+            assert_eq!(attestations.len(), 1);
+            assert_eq!(attestations[0].target_epoch, 101);
+        }
+    }
+}

--- a/crates/rvc/src/slashing/error.rs
+++ b/crates/rvc/src/slashing/error.rs
@@ -1,0 +1,13 @@
+//! Slashing protection error types.
+
+use thiserror::Error;
+
+/// Errors that can occur during slashing protection operations.
+#[derive(Debug, Error)]
+pub enum SlashingError {
+    #[error("database error: {0}")]
+    DatabaseError(#[from] rusqlite::Error),
+
+    #[error("migration error: {0}")]
+    MigrationError(String),
+}

--- a/crates/rvc/src/slashing/mod.rs
+++ b/crates/rvc/src/slashing/mod.rs
@@ -3,8 +3,12 @@
 //! This module provides types and functionality for slashing protection
 //! as specified in EIP-3076.
 
+mod db;
+mod error;
 mod types;
 
+pub use db::SlashingDb;
+pub use error::SlashingError;
 pub use types::{
     InterchangeAttestation, InterchangeBlock, InterchangeFormat, InterchangeMetadata,
     SignedAttestation, SignedBlock, ValidatorRecord,


### PR DESCRIPTION
## Summary

- Add `rusqlite` dependency with bundled SQLite for slashing protection database
- Create `SlashingDb` struct with file-based and in-memory connection support
- Implement database schema with `attestations` and `blocks` tables
- Add automatic schema migration on database open
- Implement CRUD operations for signed attestations and blocks
- Export new types (`SlashingDb`, `SlashingError`) from slashing module

## Changes

### New Files
- `crates/rvc/src/slashing/db.rs` - SQLite database layer implementation
- `crates/rvc/src/slashing/error.rs` - Error types for slashing operations

### Modified Files
- `Cargo.toml` - Add `rusqlite` workspace dependency
- `crates/rvc/Cargo.toml` - Add `rusqlite` to rvc crate
- `crates/rvc/src/slashing/mod.rs` - Export new modules

## Test Plan

- [x] Run `cargo fmt` - code is formatted
- [x] Run `cargo clippy` - no warnings
- [x] Run `cargo test` - all 214 tests pass including 16 new tests:
  - Database creation and migration tests
  - In-memory and file-based database tests
  - Attestation CRUD operations
  - Block CRUD operations
  - Unique constraint handling
  - Data persistence across connections
  - Isolation between different public keys

Closes #23

---
Generated with [Claude Code](https://claude.ai/code)