### PR TITLE
feat(timing): implement slot timing service (#31)

### DIFF
--- a/crates/rvc/src/lib.rs
+++ b/crates/rvc/src/lib.rs
@@ -5,6 +5,7 @@ pub mod crypto;
 pub mod duty_tracker;
 pub mod metrics;
 pub mod slashing;
+pub mod timing;
 
 pub mod proto {
     pub mod duty_tracker {

--- a/crates/rvc/src/timing/clock.rs
+++ b/crates/rvc/src/timing/clock.rs
@@ -1,0 +1,362 @@
+//! Slot clock implementations for Ethereum consensus timing.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::crypto::Slot;
+
+use super::error::TimingError;
+use super::{SECONDS_PER_SLOT, SLOTS_PER_EPOCH};
+
+pub trait SlotClock: Send + Sync {
+    fn genesis_time(&self) -> u64;
+    fn slot_duration(&self) -> Duration;
+    fn current_slot(&self) -> Result<Slot, TimingError>;
+    fn slot_start_time(&self, slot: Slot) -> u64;
+    fn slot_end_time(&self, slot: Slot) -> u64;
+    fn attestation_time(&self, slot: Slot) -> u64;
+    fn time_until_slot(&self, slot: Slot) -> Result<Duration, TimingError>;
+    fn time_until_attestation(&self, slot: Slot) -> Result<Duration, TimingError>;
+    fn slot_to_epoch(&self, slot: Slot) -> u64;
+    fn epoch_start_slot(&self, epoch: u64) -> Slot;
+}
+
+pub struct SystemSlotClock {
+    genesis_time: u64,
+    slot_duration: Duration,
+    slots_per_epoch: u64,
+}
+
+impl SystemSlotClock {
+    pub fn new(genesis_time: u64, slot_duration: Duration, slots_per_epoch: u64) -> Self {
+        Self { genesis_time, slot_duration, slots_per_epoch }
+    }
+
+    pub fn new_mainnet(genesis_time: u64) -> Self {
+        Self::new(genesis_time, Duration::from_secs(SECONDS_PER_SLOT), SLOTS_PER_EPOCH)
+    }
+
+    fn current_unix_time(&self) -> u64 {
+        SystemTime::now().duration_since(UNIX_EPOCH).expect("time went backwards").as_secs()
+    }
+}
+
+impl SlotClock for SystemSlotClock {
+    fn genesis_time(&self) -> u64 {
+        self.genesis_time
+    }
+
+    fn slot_duration(&self) -> Duration {
+        self.slot_duration
+    }
+
+    fn current_slot(&self) -> Result<Slot, TimingError> {
+        let current_time = self.current_unix_time();
+        if current_time < self.genesis_time {
+            return Err(TimingError::BeforeGenesis {
+                current_time,
+                genesis_time: self.genesis_time,
+            });
+        }
+        let seconds_since_genesis = current_time - self.genesis_time;
+        Ok(seconds_since_genesis / self.slot_duration.as_secs())
+    }
+
+    fn slot_start_time(&self, slot: Slot) -> u64 {
+        self.genesis_time + (slot * self.slot_duration.as_secs())
+    }
+
+    fn slot_end_time(&self, slot: Slot) -> u64 {
+        self.slot_start_time(slot + 1)
+    }
+
+    fn attestation_time(&self, slot: Slot) -> u64 {
+        self.slot_start_time(slot) + (self.slot_duration.as_secs() / 3)
+    }
+
+    fn time_until_slot(&self, slot: Slot) -> Result<Duration, TimingError> {
+        let current_time = self.current_unix_time();
+        let slot_start = self.slot_start_time(slot);
+
+        if current_time >= slot_start {
+            return Ok(Duration::ZERO);
+        }
+
+        Ok(Duration::from_secs(slot_start - current_time))
+    }
+
+    fn time_until_attestation(&self, slot: Slot) -> Result<Duration, TimingError> {
+        let current_time = self.current_unix_time();
+        let attestation_time = self.attestation_time(slot);
+
+        if current_time >= attestation_time {
+            return Ok(Duration::ZERO);
+        }
+
+        Ok(Duration::from_secs(attestation_time - current_time))
+    }
+
+    fn slot_to_epoch(&self, slot: Slot) -> u64 {
+        slot / self.slots_per_epoch
+    }
+
+    fn epoch_start_slot(&self, epoch: u64) -> Slot {
+        epoch * self.slots_per_epoch
+    }
+}
+
+pub struct MockSlotClock {
+    genesis_time: u64,
+    slot_duration: Duration,
+    slots_per_epoch: u64,
+    current_time: std::sync::atomic::AtomicU64,
+}
+
+impl MockSlotClock {
+    pub fn new(genesis_time: u64, slot_duration: Duration, slots_per_epoch: u64) -> Self {
+        Self {
+            genesis_time,
+            slot_duration,
+            slots_per_epoch,
+            current_time: std::sync::atomic::AtomicU64::new(genesis_time),
+        }
+    }
+
+    pub fn set_current_time(&self, time: u64) {
+        self.current_time.store(time, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    pub fn advance_time(&self, seconds: u64) {
+        self.current_time.fetch_add(seconds, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    pub fn set_slot(&self, slot: Slot) {
+        let slot_start = self.genesis_time + (slot * self.slot_duration.as_secs());
+        self.set_current_time(slot_start);
+    }
+
+    fn get_current_time(&self) -> u64 {
+        self.current_time.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+impl SlotClock for MockSlotClock {
+    fn genesis_time(&self) -> u64 {
+        self.genesis_time
+    }
+
+    fn slot_duration(&self) -> Duration {
+        self.slot_duration
+    }
+
+    fn current_slot(&self) -> Result<Slot, TimingError> {
+        let current_time = self.get_current_time();
+        if current_time < self.genesis_time {
+            return Err(TimingError::BeforeGenesis {
+                current_time,
+                genesis_time: self.genesis_time,
+            });
+        }
+        let seconds_since_genesis = current_time - self.genesis_time;
+        Ok(seconds_since_genesis / self.slot_duration.as_secs())
+    }
+
+    fn slot_start_time(&self, slot: Slot) -> u64 {
+        self.genesis_time + (slot * self.slot_duration.as_secs())
+    }
+
+    fn slot_end_time(&self, slot: Slot) -> u64 {
+        self.slot_start_time(slot + 1)
+    }
+
+    fn attestation_time(&self, slot: Slot) -> u64 {
+        self.slot_start_time(slot) + (self.slot_duration.as_secs() / 3)
+    }
+
+    fn time_until_slot(&self, slot: Slot) -> Result<Duration, TimingError> {
+        let current_time = self.get_current_time();
+        let slot_start = self.slot_start_time(slot);
+
+        if current_time >= slot_start {
+            return Ok(Duration::ZERO);
+        }
+
+        Ok(Duration::from_secs(slot_start - current_time))
+    }
+
+    fn time_until_attestation(&self, slot: Slot) -> Result<Duration, TimingError> {
+        let current_time = self.get_current_time();
+        let attestation_time = self.attestation_time(slot);
+
+        if current_time >= attestation_time {
+            return Ok(Duration::ZERO);
+        }
+
+        Ok(Duration::from_secs(attestation_time - current_time))
+    }
+
+    fn slot_to_epoch(&self, slot: Slot) -> u64 {
+        slot / self.slots_per_epoch
+    }
+
+    fn epoch_start_slot(&self, epoch: u64) -> Slot {
+        epoch * self.slots_per_epoch
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_GENESIS_TIME: u64 = 1606824023; // Mainnet genesis
+
+    fn create_mock_clock() -> MockSlotClock {
+        MockSlotClock::new(TEST_GENESIS_TIME, Duration::from_secs(12), 32)
+    }
+
+    #[test]
+    fn test_slot_clock_genesis_time() {
+        let clock = create_mock_clock();
+        assert_eq!(clock.genesis_time(), TEST_GENESIS_TIME);
+    }
+
+    #[test]
+    fn test_slot_clock_slot_duration() {
+        let clock = create_mock_clock();
+        assert_eq!(clock.slot_duration(), Duration::from_secs(12));
+    }
+
+    #[test]
+    fn test_current_slot_at_genesis() {
+        let clock = create_mock_clock();
+        clock.set_current_time(TEST_GENESIS_TIME);
+        assert_eq!(clock.current_slot().unwrap(), 0);
+    }
+
+    #[test]
+    fn test_current_slot_after_one_slot() {
+        let clock = create_mock_clock();
+        clock.set_current_time(TEST_GENESIS_TIME + 12);
+        assert_eq!(clock.current_slot().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_current_slot_mid_slot() {
+        let clock = create_mock_clock();
+        clock.set_current_time(TEST_GENESIS_TIME + 6);
+        assert_eq!(clock.current_slot().unwrap(), 0);
+    }
+
+    #[test]
+    fn test_current_slot_multiple_slots() {
+        let clock = create_mock_clock();
+        clock.set_current_time(TEST_GENESIS_TIME + (100 * 12));
+        assert_eq!(clock.current_slot().unwrap(), 100);
+    }
+
+    #[test]
+    fn test_current_slot_before_genesis() {
+        let clock = create_mock_clock();
+        clock.set_current_time(TEST_GENESIS_TIME - 100);
+        let result = clock.current_slot();
+        assert!(matches!(result, Err(TimingError::BeforeGenesis { .. })));
+    }
+
+    #[test]
+    fn test_slot_start_time() {
+        let clock = create_mock_clock();
+        assert_eq!(clock.slot_start_time(0), TEST_GENESIS_TIME);
+        assert_eq!(clock.slot_start_time(1), TEST_GENESIS_TIME + 12);
+        assert_eq!(clock.slot_start_time(100), TEST_GENESIS_TIME + 1200);
+    }
+
+    #[test]
+    fn test_slot_end_time() {
+        let clock = create_mock_clock();
+        assert_eq!(clock.slot_end_time(0), TEST_GENESIS_TIME + 12);
+        assert_eq!(clock.slot_end_time(1), TEST_GENESIS_TIME + 24);
+    }
+
+    #[test]
+    fn test_attestation_time() {
+        let clock = create_mock_clock();
+        assert_eq!(clock.attestation_time(0), TEST_GENESIS_TIME + 4);
+        assert_eq!(clock.attestation_time(1), TEST_GENESIS_TIME + 16);
+    }
+
+    #[test]
+    fn test_time_until_slot_in_future() {
+        let clock = create_mock_clock();
+        clock.set_current_time(TEST_GENESIS_TIME);
+        let time_until = clock.time_until_slot(10).unwrap();
+        assert_eq!(time_until, Duration::from_secs(120));
+    }
+
+    #[test]
+    fn test_time_until_slot_already_started() {
+        let clock = create_mock_clock();
+        clock.set_current_time(TEST_GENESIS_TIME + 100);
+        let time_until = clock.time_until_slot(5).unwrap();
+        assert_eq!(time_until, Duration::ZERO);
+    }
+
+    #[test]
+    fn test_time_until_attestation_in_future() {
+        let clock = create_mock_clock();
+        clock.set_current_time(TEST_GENESIS_TIME);
+        let time_until = clock.time_until_attestation(0).unwrap();
+        assert_eq!(time_until, Duration::from_secs(4));
+    }
+
+    #[test]
+    fn test_time_until_attestation_already_passed() {
+        let clock = create_mock_clock();
+        clock.set_current_time(TEST_GENESIS_TIME + 10);
+        let time_until = clock.time_until_attestation(0).unwrap();
+        assert_eq!(time_until, Duration::ZERO);
+    }
+
+    #[test]
+    fn test_slot_to_epoch() {
+        let clock = create_mock_clock();
+        assert_eq!(clock.slot_to_epoch(0), 0);
+        assert_eq!(clock.slot_to_epoch(31), 0);
+        assert_eq!(clock.slot_to_epoch(32), 1);
+        assert_eq!(clock.slot_to_epoch(64), 2);
+        assert_eq!(clock.slot_to_epoch(100), 3);
+    }
+
+    #[test]
+    fn test_epoch_start_slot() {
+        let clock = create_mock_clock();
+        assert_eq!(clock.epoch_start_slot(0), 0);
+        assert_eq!(clock.epoch_start_slot(1), 32);
+        assert_eq!(clock.epoch_start_slot(2), 64);
+        assert_eq!(clock.epoch_start_slot(10), 320);
+    }
+
+    #[test]
+    fn test_mock_clock_set_slot() {
+        let clock = create_mock_clock();
+        clock.set_slot(50);
+        assert_eq!(clock.current_slot().unwrap(), 50);
+    }
+
+    #[test]
+    fn test_mock_clock_advance_time() {
+        let clock = create_mock_clock();
+        clock.set_current_time(TEST_GENESIS_TIME);
+        assert_eq!(clock.current_slot().unwrap(), 0);
+        clock.advance_time(12);
+        assert_eq!(clock.current_slot().unwrap(), 1);
+        clock.advance_time(24);
+        assert_eq!(clock.current_slot().unwrap(), 3);
+    }
+
+    #[test]
+    fn test_system_slot_clock_new_mainnet() {
+        let clock = SystemSlotClock::new_mainnet(TEST_GENESIS_TIME);
+        assert_eq!(clock.genesis_time(), TEST_GENESIS_TIME);
+        assert_eq!(clock.slot_duration(), Duration::from_secs(12));
+        assert_eq!(clock.slots_per_epoch, 32);
+    }
+}

--- a/crates/rvc/src/timing/error.rs
+++ b/crates/rvc/src/timing/error.rs
@@ -1,0 +1,38 @@
+//! Timing service error types.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum TimingError {
+    #[error("current time {current_time} is before genesis time {genesis_time}")]
+    BeforeGenesis { current_time: u64, genesis_time: u64 },
+
+    #[error("slot {slot} has not yet started")]
+    SlotNotStarted { slot: u64 },
+
+    #[error("timer cancelled")]
+    Cancelled,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_before_genesis_display() {
+        let err = TimingError::BeforeGenesis { current_time: 100, genesis_time: 200 };
+        assert_eq!(err.to_string(), "current time 100 is before genesis time 200");
+    }
+
+    #[test]
+    fn test_slot_not_started_display() {
+        let err = TimingError::SlotNotStarted { slot: 42 };
+        assert_eq!(err.to_string(), "slot 42 has not yet started");
+    }
+
+    #[test]
+    fn test_cancelled_display() {
+        let err = TimingError::Cancelled;
+        assert_eq!(err.to_string(), "timer cancelled");
+    }
+}

--- a/crates/rvc/src/timing/mod.rs
+++ b/crates/rvc/src/timing/mod.rs
@@ -1,0 +1,18 @@
+//! Slot timing service for Ethereum consensus.
+//!
+//! This module provides slot timing functionality including:
+//! - `SlotClock` trait for slot time calculations
+//! - `SystemSlotClock` implementation using system time
+//! - `AttestationTimer` for triggering attestations at 1/3 slot time
+
+mod clock;
+mod error;
+mod timer;
+
+pub use clock::{MockSlotClock, SlotClock, SystemSlotClock};
+pub use error::TimingError;
+pub use timer::{AttestationTimer, AttestationTimerHandle};
+
+pub const SECONDS_PER_SLOT: u64 = 12;
+pub const SLOTS_PER_EPOCH: u64 = 32;
+pub const ATTESTATION_DELAY_FRACTION: u64 = 3;

--- a/crates/rvc/src/timing/timer.rs
+++ b/crates/rvc/src/timing/timer.rs
@@ -1,0 +1,278 @@
+//! Attestation timer for triggering duties at the correct time within a slot.
+
+use std::sync::Arc;
+
+use lazy_static::lazy_static;
+use prometheus::{Gauge, Histogram, HistogramOpts, Opts};
+use tokio::sync::watch;
+use tokio::time::{sleep, Duration};
+
+use crate::crypto::Slot;
+use crate::metrics::REGISTRY;
+
+use super::clock::SlotClock;
+use super::error::TimingError;
+
+lazy_static! {
+    static ref RVC_SLOT_TIMING_CURRENT_SLOT: Gauge = {
+        let opts = Opts::new("rvc_slot_timing_current_slot", "The current slot number");
+        let gauge =
+            Gauge::with_opts(opts).expect("Failed to create rvc_slot_timing_current_slot metric");
+        REGISTRY
+            .register(Box::new(gauge.clone()))
+            .expect("Failed to register rvc_slot_timing_current_slot metric");
+        gauge
+    };
+    static ref RVC_SLOT_TIMING_DRIFT_SECONDS: Gauge = {
+        let opts = Opts::new(
+            "rvc_slot_timing_drift_seconds",
+            "Clock drift in seconds relative to expected slot timing",
+        );
+        let gauge =
+            Gauge::with_opts(opts).expect("Failed to create rvc_slot_timing_drift_seconds metric");
+        REGISTRY
+            .register(Box::new(gauge.clone()))
+            .expect("Failed to register rvc_slot_timing_drift_seconds metric");
+        gauge
+    };
+    static ref RVC_SLOT_TIMING_ATTESTATION_DELAY_SECONDS: Histogram = {
+        let opts = HistogramOpts::new(
+            "rvc_slot_timing_attestation_delay_seconds",
+            "Delay in seconds from the expected attestation time",
+        )
+        .buckets(vec![0.0, 0.1, 0.5, 1.0, 2.0, 4.0, 8.0, 12.0]);
+        let histogram = Histogram::with_opts(opts)
+            .expect("Failed to create rvc_slot_timing_attestation_delay_seconds metric");
+        REGISTRY
+            .register(Box::new(histogram.clone()))
+            .expect("Failed to register rvc_slot_timing_attestation_delay_seconds metric");
+        histogram
+    };
+}
+
+pub struct AttestationTimer<C: SlotClock> {
+    clock: Arc<C>,
+    cancel_rx: watch::Receiver<bool>,
+}
+
+impl<C: SlotClock> AttestationTimer<C> {
+    pub fn new(clock: Arc<C>) -> (Self, AttestationTimerHandle) {
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let timer = Self { clock, cancel_rx };
+        let handle = AttestationTimerHandle { cancel_tx };
+        (timer, handle)
+    }
+
+    pub async fn wait_for_slot_start(&mut self, slot: Slot) -> Result<(), TimingError> {
+        let time_until_slot = self.clock.time_until_slot(slot)?;
+
+        if time_until_slot.is_zero() {
+            return Ok(());
+        }
+
+        self.wait_with_cancellation(time_until_slot).await
+    }
+
+    pub async fn wait_for_attestation_time(&mut self, slot: Slot) -> Result<(), TimingError> {
+        let time_until_attestation = self.clock.time_until_attestation(slot)?;
+
+        if time_until_attestation.is_zero() {
+            self.record_attestation_delay(slot);
+            return Ok(());
+        }
+
+        let result = self.wait_with_cancellation(time_until_attestation).await;
+
+        if result.is_ok() {
+            self.record_attestation_delay(slot);
+        }
+
+        result
+    }
+
+    pub async fn run_slot_loop<F, Fut>(&mut self, mut on_attestation: F) -> Result<(), TimingError>
+    where
+        F: FnMut(Slot) -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        loop {
+            let current_slot = match self.clock.current_slot() {
+                Ok(slot) => slot,
+                Err(TimingError::BeforeGenesis { .. }) => {
+                    sleep(Duration::from_secs(1)).await;
+                    continue;
+                }
+                Err(e) => return Err(e),
+            };
+
+            self.update_slot_metrics(current_slot);
+
+            self.wait_for_attestation_time(current_slot).await?;
+            on_attestation(current_slot).await;
+
+            let next_slot = current_slot + 1;
+            self.wait_for_slot_start(next_slot).await?;
+        }
+    }
+
+    async fn wait_with_cancellation(&mut self, duration: Duration) -> Result<(), TimingError> {
+        let sleep_future = sleep(duration);
+        tokio::pin!(sleep_future);
+
+        tokio::select! {
+            _ = &mut sleep_future => Ok(()),
+            _ = self.cancel_rx.changed() => {
+                if *self.cancel_rx.borrow() {
+                    Err(TimingError::Cancelled)
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn record_attestation_delay(&self, slot: Slot) {
+        let attestation_time = self.clock.attestation_time(slot);
+        let current_time = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_secs();
+
+        if current_time >= attestation_time {
+            let delay = current_time - attestation_time;
+            RVC_SLOT_TIMING_ATTESTATION_DELAY_SECONDS.observe(delay as f64);
+        }
+    }
+
+    fn update_slot_metrics(&self, slot: Slot) {
+        RVC_SLOT_TIMING_CURRENT_SLOT.set(slot as f64);
+
+        let slot_start = self.clock.slot_start_time(slot);
+        let current_time = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_secs();
+
+        let expected_slot_time = slot_start + (self.clock.slot_duration().as_secs() / 2);
+        let drift = if current_time > expected_slot_time {
+            (current_time - expected_slot_time) as f64
+        } else {
+            -((expected_slot_time - current_time) as f64)
+        };
+
+        RVC_SLOT_TIMING_DRIFT_SECONDS.set(drift);
+    }
+}
+
+pub struct AttestationTimerHandle {
+    cancel_tx: watch::Sender<bool>,
+}
+
+impl AttestationTimerHandle {
+    pub fn cancel(&self) {
+        let _ = self.cancel_tx.send(true);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::timing::clock::MockSlotClock;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
+
+    const TEST_GENESIS_TIME: u64 = 1606824023;
+
+    fn create_mock_clock() -> Arc<MockSlotClock> {
+        Arc::new(MockSlotClock::new(TEST_GENESIS_TIME, Duration::from_secs(12), 32))
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_slot_start_already_started() {
+        let clock = create_mock_clock();
+        clock.set_slot(10);
+
+        let (mut timer, _handle) = AttestationTimer::new(clock);
+        let result = timer.wait_for_slot_start(5).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_attestation_time_already_passed() {
+        let clock = create_mock_clock();
+        clock.set_current_time(TEST_GENESIS_TIME + 10);
+
+        let (mut timer, _handle) = AttestationTimer::new(clock);
+        let result = timer.wait_for_attestation_time(0).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_timer_cancellation() {
+        let clock = create_mock_clock();
+        clock.set_current_time(TEST_GENESIS_TIME);
+
+        let (mut timer, handle) = AttestationTimer::new(clock);
+
+        let timer_task = tokio::spawn(async move { timer.wait_for_slot_start(1000).await });
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        handle.cancel();
+
+        let result = timer_task.await.unwrap();
+        assert!(matches!(result, Err(TimingError::Cancelled)));
+    }
+
+    #[tokio::test]
+    async fn test_slot_loop_calls_callback() {
+        let clock = create_mock_clock();
+        clock.set_current_time(TEST_GENESIS_TIME + 4);
+
+        let (mut timer, handle) = AttestationTimer::new(clock);
+        let call_count = Arc::new(AtomicU64::new(0));
+        let call_count_clone = call_count.clone();
+
+        let timer_task = tokio::spawn(async move {
+            timer
+                .run_slot_loop(|_slot| {
+                    let cc = call_count_clone.clone();
+                    async move {
+                        cc.fetch_add(1, Ordering::SeqCst);
+                    }
+                })
+                .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        handle.cancel();
+
+        let _ = timer_task.await;
+        assert!(call_count.load(Ordering::SeqCst) >= 1);
+    }
+
+    #[test]
+    fn test_attestation_timer_handle_cancel() {
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let handle = AttestationTimerHandle { cancel_tx };
+
+        assert!(!*cancel_rx.borrow());
+        handle.cancel();
+        assert!(cancel_rx.has_changed().unwrap_or(false) || *cancel_rx.borrow());
+    }
+
+    #[test]
+    fn test_slot_timing_metrics_exist() {
+        lazy_static::initialize(&RVC_SLOT_TIMING_CURRENT_SLOT);
+        lazy_static::initialize(&RVC_SLOT_TIMING_DRIFT_SECONDS);
+        lazy_static::initialize(&RVC_SLOT_TIMING_ATTESTATION_DELAY_SECONDS);
+
+        RVC_SLOT_TIMING_CURRENT_SLOT.set(100.0);
+        assert_eq!(RVC_SLOT_TIMING_CURRENT_SLOT.get(), 100.0);
+
+        RVC_SLOT_TIMING_DRIFT_SECONDS.set(-0.5);
+        assert_eq!(RVC_SLOT_TIMING_DRIFT_SECONDS.get(), -0.5);
+
+        RVC_SLOT_TIMING_ATTESTATION_DELAY_SECONDS.observe(1.5);
+        assert!(RVC_SLOT_TIMING_ATTESTATION_DELAY_SECONDS.get_sample_count() >= 1);
+    }
+}


### PR DESCRIPTION
## Summary

- Implements `SlotClock` trait with `current_slot()`, `slot_start_time()`, `attestation_time()` methods for Ethereum consensus timing
- Adds `SystemSlotClock` implementation using system time with configurable genesis and slot duration
- Provides `MockSlotClock` for testing with controllable time advancement
- Implements `AttestationTimer` that triggers attestation callbacks at 1/3 slot time (4 seconds for 12-second slots)
- Handles clock drift gracefully and exposes timing metrics for monitoring

## Test plan

- [x] Unit tests for `SlotClock` trait methods (slot calculation, timing, epoch conversion)
- [x] Unit tests for `MockSlotClock` time manipulation
- [x] Async tests for `AttestationTimer` wait operations
- [x] Tests for timer cancellation via `AttestationTimerHandle`
- [x] Tests for slot loop callback execution
- [x] All tests pass with `cargo test --package rvc`
- [x] Code passes `cargo clippy` with no warnings
- [x] Code formatted with `cargo fmt`

## Implementation Details

### SlotClock Trait
```rust
pub trait SlotClock: Send + Sync {
    fn genesis_time(&self) -> u64;
    fn slot_duration(&self) -> Duration;
    fn current_slot(&self) -> Result<Slot, TimingError>;
    fn slot_start_time(&self, slot: Slot) -> u64;
    fn attestation_time(&self, slot: Slot) -> u64;
    fn time_until_slot(&self, slot: Slot) -> Result<Duration, TimingError>;
    fn time_until_attestation(&self, slot: Slot) -> Result<Duration, TimingError>;
    fn slot_to_epoch(&self, slot: Slot) -> u64;
    fn epoch_start_slot(&self, epoch: u64) -> Slot;
}
```

### Metrics Added
- `rvc_slot_timing_current_slot`: Gauge for tracking current slot number
- `rvc_slot_timing_drift_seconds`: Gauge for clock drift measurement
- `rvc_slot_timing_attestation_delay_seconds`: Histogram for attestation timing delays

### Constants
- `SECONDS_PER_SLOT = 12`: Standard Ethereum slot duration
- `SLOTS_PER_EPOCH = 32`: Slots per epoch
- `ATTESTATION_DELAY_FRACTION = 3`: Attestation at 1/3 slot time

Closes #31

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)