### PR TITLE
feat(signer): implement signer service with slashing protection (#32)

### DIFF
--- a/crates/rvc/src/crypto/key_manager.rs
+++ b/crates/rvc/src/crypto/key_manager.rs
@@ -297,6 +297,14 @@ impl KeyManager {
     pub fn is_empty(&self) -> bool {
         self.keys.is_empty()
     }
+
+    /// Inserts a secret key into the key manager.
+    /// This is only available for testing purposes.
+    #[cfg(test)]
+    pub fn insert(&mut self, secret_key: SecretKey) {
+        let pubkey = secret_key.public_key();
+        self.keys.insert(pubkey.to_bytes(), secret_key);
+    }
 }
 
 impl Default for KeyManager {

--- a/crates/rvc/src/lib.rs
+++ b/crates/rvc/src/lib.rs
@@ -4,6 +4,8 @@ pub mod beacon;
 pub mod crypto;
 pub mod duty_tracker;
 pub mod metrics;
+pub mod propagator;
+pub mod signer;
 pub mod slashing;
 pub mod timing;
 

--- a/crates/rvc/src/signer/mod.rs
+++ b/crates/rvc/src/signer/mod.rs
@@ -1,0 +1,466 @@
+//! Signer service combining key management with slashing protection.
+//!
+//! This module provides a signing service that ensures all attestation
+//! signatures are checked against slashing protection rules before signing.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use thiserror::Error;
+
+use crate::crypto::{
+    sign_attestation, AttestationData, Fork, KeyManager, PublicKey, Root, Signature,
+};
+use crate::metrics::definitions::{
+    slashing_result, RVC_ATTESTATIONS_TOTAL, RVC_SIGNING_DURATION_SECONDS,
+    RVC_SLASHING_PROTECTION_CHECKS_TOTAL,
+};
+use crate::slashing::{SlashingDb, SlashingError};
+
+/// Errors that can occur during signing operations.
+#[derive(Debug, Error)]
+pub enum SignerError {
+    #[error("key not found for pubkey: {0}")]
+    KeyNotFound(String),
+
+    #[error("slashing protection blocked signing: {0}")]
+    SlashingProtectionBlocked(#[from] SlashingError),
+
+    #[error("failed to record attestation: {0}")]
+    RecordingFailed(SlashingError),
+}
+
+/// Service that combines key management with slashing protection for signing.
+pub struct SignerService {
+    key_manager: Arc<KeyManager>,
+    slashing_db: Arc<SlashingDb>,
+}
+
+impl SignerService {
+    /// Creates a new SignerService with the provided key manager and slashing database.
+    pub fn new(key_manager: Arc<KeyManager>, slashing_db: Arc<SlashingDb>) -> Self {
+        Self { key_manager, slashing_db }
+    }
+
+    /// Signs an attestation after checking slashing protection.
+    ///
+    /// This method:
+    /// 1. Checks if the attestation is safe to sign according to EIP-3076 rules
+    /// 2. If blocked, increments metrics and returns an error
+    /// 3. If safe, retrieves the secret key and signs the attestation
+    /// 4. Records the attestation in the slashing database
+    /// 5. Updates metrics for signing duration and success count
+    ///
+    /// Returns the signature on success, or an error if blocked or key not found.
+    pub fn sign_attestation(
+        &self,
+        attestation_data: &AttestationData,
+        pubkey: &PublicKey,
+        fork: &Fork,
+        genesis_validators_root: Root,
+    ) -> Result<Signature, SignerError> {
+        let start = Instant::now();
+
+        let pubkey_hex = hex::encode(pubkey.to_bytes());
+
+        let source_epoch = attestation_data.source.epoch;
+        let target_epoch = attestation_data.target.epoch;
+
+        if let Err(e) = self.slashing_db.is_safe_to_sign(&pubkey_hex, source_epoch, target_epoch) {
+            RVC_SLASHING_PROTECTION_CHECKS_TOTAL
+                .with_label_values(&[slashing_result::BLOCKED])
+                .inc();
+            RVC_ATTESTATIONS_TOTAL.with_label_values(&["failed"]).inc();
+            return Err(SignerError::SlashingProtectionBlocked(e));
+        }
+
+        RVC_SLASHING_PROTECTION_CHECKS_TOTAL.with_label_values(&[slashing_result::SAFE]).inc();
+
+        let secret_key = self
+            .key_manager
+            .get_secret_key(pubkey)
+            .ok_or_else(|| SignerError::KeyNotFound(pubkey_hex.clone()))?;
+
+        let signature =
+            sign_attestation(attestation_data, secret_key, fork, genesis_validators_root);
+
+        let signing_root = hex::encode(crate::crypto::compute_signing_root(
+            attestation_data,
+            crate::crypto::compute_domain(
+                crate::crypto::DOMAIN_BEACON_ATTESTER,
+                if target_epoch >= fork.epoch {
+                    fork.current_version
+                } else {
+                    fork.previous_version
+                },
+                genesis_validators_root,
+            ),
+        ));
+
+        if let Err(e) = self.slashing_db.record_attestation(
+            &pubkey_hex,
+            source_epoch,
+            target_epoch,
+            Some(signing_root),
+        ) {
+            RVC_ATTESTATIONS_TOTAL.with_label_values(&["failed"]).inc();
+            return Err(SignerError::RecordingFailed(e));
+        }
+
+        let duration = start.elapsed().as_secs_f64();
+        RVC_SIGNING_DURATION_SECONDS.with_label_values(&[]).observe(duration);
+        RVC_ATTESTATIONS_TOTAL.with_label_values(&["success"]).inc();
+
+        Ok(signature)
+    }
+
+    /// Returns a reference to the underlying key manager.
+    pub fn key_manager(&self) -> &KeyManager {
+        &self.key_manager
+    }
+
+    /// Returns a reference to the underlying slashing database.
+    pub fn slashing_db(&self) -> &SlashingDb {
+        &self.slashing_db
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::{
+        compute_domain, compute_signing_root, Checkpoint, SecretKey, DOMAIN_BEACON_ATTESTER,
+    };
+
+    fn create_test_key_manager_with_key(secret_key: SecretKey) -> KeyManager {
+        let mut manager = KeyManager::new();
+        manager.insert(secret_key);
+        manager
+    }
+
+    fn create_test_attestation_data(source_epoch: u64, target_epoch: u64) -> AttestationData {
+        AttestationData {
+            slot: 1000,
+            index: 5,
+            beacon_block_root: [0x11; 32],
+            source: Checkpoint { epoch: source_epoch, root: [0x22; 32] },
+            target: Checkpoint { epoch: target_epoch, root: [0x33; 32] },
+        }
+    }
+
+    fn create_test_fork() -> Fork {
+        Fork {
+            previous_version: [0x00, 0x00, 0x00, 0x01],
+            current_version: [0x00, 0x00, 0x00, 0x02],
+            epoch: 50,
+        }
+    }
+
+    #[test]
+    fn test_signer_service_creation() {
+        let key_manager = Arc::new(KeyManager::new());
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().expect("failed to open db"));
+
+        let service = SignerService::new(key_manager.clone(), slashing_db.clone());
+
+        assert!(service.key_manager().is_empty());
+    }
+
+    #[test]
+    fn test_sign_attestation_success() {
+        let secret_key = SecretKey::generate();
+        let pubkey = secret_key.public_key();
+        let key_manager = Arc::new(create_test_key_manager_with_key(secret_key));
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().expect("failed to open db"));
+
+        let service = SignerService::new(key_manager, slashing_db.clone());
+
+        let attestation_data = create_test_attestation_data(100, 101);
+        let fork = create_test_fork();
+        let genesis_root = [0xaa; 32];
+
+        let result = service.sign_attestation(&attestation_data, &pubkey, &fork, genesis_root);
+
+        assert!(result.is_ok());
+        let signature = result.unwrap();
+
+        let fork_version = fork.current_version;
+        let domain = compute_domain(DOMAIN_BEACON_ATTESTER, fork_version, genesis_root);
+        let signing_root = compute_signing_root(&attestation_data, domain);
+
+        assert!(signature.verify(&pubkey, &signing_root).is_ok());
+
+        let pubkey_hex = hex::encode(pubkey.to_bytes());
+        let attestations = slashing_db.get_attestations(&pubkey_hex).expect("failed to get");
+        assert_eq!(attestations.len(), 1);
+        assert_eq!(attestations[0].source_epoch, 100);
+        assert_eq!(attestations[0].target_epoch, 101);
+        assert!(attestations[0].signing_root.is_some());
+    }
+
+    #[test]
+    fn test_sign_attestation_success_uses_previous_fork_version() {
+        let secret_key = SecretKey::generate();
+        let pubkey = secret_key.public_key();
+        let key_manager = Arc::new(create_test_key_manager_with_key(secret_key));
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().expect("failed to open db"));
+
+        let service = SignerService::new(key_manager, slashing_db);
+
+        let fork = Fork {
+            previous_version: [0x00, 0x00, 0x00, 0x01],
+            current_version: [0x00, 0x00, 0x00, 0x02],
+            epoch: 100,
+        };
+        let attestation_data = create_test_attestation_data(50, 51);
+        let genesis_root = [0xaa; 32];
+
+        let result = service.sign_attestation(&attestation_data, &pubkey, &fork, genesis_root);
+
+        assert!(result.is_ok());
+        let signature = result.unwrap();
+
+        let domain = compute_domain(DOMAIN_BEACON_ATTESTER, fork.previous_version, genesis_root);
+        let signing_root = compute_signing_root(&attestation_data, domain);
+
+        assert!(signature.verify(&pubkey, &signing_root).is_ok());
+    }
+
+    #[test]
+    fn test_sign_attestation_records_in_slashing_db() {
+        let secret_key = SecretKey::generate();
+        let pubkey = secret_key.public_key();
+        let key_manager = Arc::new(create_test_key_manager_with_key(secret_key));
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().expect("failed to open db"));
+
+        let service = SignerService::new(key_manager, slashing_db.clone());
+
+        let attestation_data = create_test_attestation_data(100, 101);
+        let fork = create_test_fork();
+        let genesis_root = [0xaa; 32];
+
+        service
+            .sign_attestation(&attestation_data, &pubkey, &fork, genesis_root)
+            .expect("signing should succeed");
+
+        let pubkey_hex = hex::encode(pubkey.to_bytes());
+        let attestations = slashing_db.get_attestations(&pubkey_hex).expect("failed to get");
+        assert_eq!(attestations.len(), 1);
+        assert_eq!(attestations[0].pubkey, pubkey_hex);
+        assert_eq!(attestations[0].source_epoch, 100);
+        assert_eq!(attestations[0].target_epoch, 101);
+    }
+
+    #[test]
+    fn test_sign_attestation_prevents_double_vote_after_signing() {
+        let secret_key = SecretKey::generate();
+        let pubkey = secret_key.public_key();
+        let key_manager = Arc::new(create_test_key_manager_with_key(secret_key));
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().expect("failed to open db"));
+
+        let service = SignerService::new(key_manager, slashing_db);
+
+        let attestation_data1 = create_test_attestation_data(100, 101);
+        let fork = create_test_fork();
+        let genesis_root = [0xaa; 32];
+
+        let result1 = service.sign_attestation(&attestation_data1, &pubkey, &fork, genesis_root);
+        assert!(result1.is_ok());
+
+        let attestation_data2 = create_test_attestation_data(99, 101);
+        let result2 = service.sign_attestation(&attestation_data2, &pubkey, &fork, genesis_root);
+
+        assert!(result2.is_err());
+        match result2.unwrap_err() {
+            SignerError::SlashingProtectionBlocked(_) => {}
+            _ => panic!("expected SlashingProtectionBlocked error"),
+        }
+    }
+
+    #[test]
+    fn test_sign_attestation_allows_multiple_non_conflicting() {
+        let secret_key = SecretKey::generate();
+        let pubkey = secret_key.public_key();
+        let key_manager = Arc::new(create_test_key_manager_with_key(secret_key));
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().expect("failed to open db"));
+
+        let service = SignerService::new(key_manager, slashing_db.clone());
+
+        let fork = create_test_fork();
+        let genesis_root = [0xaa; 32];
+
+        let attestation_data1 = create_test_attestation_data(100, 101);
+        let result1 = service.sign_attestation(&attestation_data1, &pubkey, &fork, genesis_root);
+        assert!(result1.is_ok());
+
+        let attestation_data2 = create_test_attestation_data(101, 102);
+        let result2 = service.sign_attestation(&attestation_data2, &pubkey, &fork, genesis_root);
+        assert!(result2.is_ok());
+
+        let attestation_data3 = create_test_attestation_data(102, 103);
+        let result3 = service.sign_attestation(&attestation_data3, &pubkey, &fork, genesis_root);
+        assert!(result3.is_ok());
+
+        let pubkey_hex = hex::encode(pubkey.to_bytes());
+        let attestations = slashing_db.get_attestations(&pubkey_hex).expect("failed to get");
+        assert_eq!(attestations.len(), 3);
+    }
+
+    #[test]
+    fn test_sign_attestation_key_not_found() {
+        let key_manager = Arc::new(KeyManager::new());
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().expect("failed to open db"));
+        let service = SignerService::new(key_manager, slashing_db);
+
+        let secret_key = SecretKey::generate();
+        let pubkey = secret_key.public_key();
+        let attestation_data = create_test_attestation_data(100, 101);
+        let fork = create_test_fork();
+        let genesis_root = [0xaa; 32];
+
+        let result = service.sign_attestation(&attestation_data, &pubkey, &fork, genesis_root);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SignerError::KeyNotFound(pk) => {
+                assert_eq!(pk, hex::encode(pubkey.to_bytes()));
+            }
+            _ => panic!("expected KeyNotFound error"),
+        }
+    }
+
+    #[test]
+    fn test_sign_attestation_slashing_blocked_double_vote() {
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().expect("failed to open db"));
+
+        let secret_key = SecretKey::generate();
+        let pubkey = secret_key.public_key();
+        let pubkey_hex = hex::encode(pubkey.to_bytes());
+
+        slashing_db.record_attestation(&pubkey_hex, 100, 101, None).expect("record should succeed");
+
+        let key_manager = Arc::new(KeyManager::new());
+        let service = SignerService::new(key_manager, slashing_db);
+
+        let attestation_data = create_test_attestation_data(99, 101);
+        let fork = create_test_fork();
+        let genesis_root = [0xaa; 32];
+
+        let result = service.sign_attestation(&attestation_data, &pubkey, &fork, genesis_root);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SignerError::SlashingProtectionBlocked(_) => {}
+            _ => panic!("expected SlashingProtectionBlocked error"),
+        }
+    }
+
+    #[test]
+    fn test_sign_attestation_slashing_blocked_surrounding_vote() {
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().expect("failed to open db"));
+
+        let secret_key = SecretKey::generate();
+        let pubkey = secret_key.public_key();
+        let pubkey_hex = hex::encode(pubkey.to_bytes());
+
+        slashing_db.record_attestation(&pubkey_hex, 5, 10, None).expect("record should succeed");
+
+        let key_manager = Arc::new(KeyManager::new());
+        let service = SignerService::new(key_manager, slashing_db);
+
+        let attestation_data = create_test_attestation_data(4, 11);
+        let fork = create_test_fork();
+        let genesis_root = [0xaa; 32];
+
+        let result = service.sign_attestation(&attestation_data, &pubkey, &fork, genesis_root);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SignerError::SlashingProtectionBlocked(_) => {}
+            _ => panic!("expected SlashingProtectionBlocked error"),
+        }
+    }
+
+    #[test]
+    fn test_sign_attestation_slashing_blocked_surrounded_vote() {
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().expect("failed to open db"));
+
+        let secret_key = SecretKey::generate();
+        let pubkey = secret_key.public_key();
+        let pubkey_hex = hex::encode(pubkey.to_bytes());
+
+        slashing_db.record_attestation(&pubkey_hex, 4, 11, None).expect("record should succeed");
+
+        let key_manager = Arc::new(KeyManager::new());
+        let service = SignerService::new(key_manager, slashing_db);
+
+        let attestation_data = create_test_attestation_data(5, 10);
+        let fork = create_test_fork();
+        let genesis_root = [0xaa; 32];
+
+        let result = service.sign_attestation(&attestation_data, &pubkey, &fork, genesis_root);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SignerError::SlashingProtectionBlocked(_) => {}
+            _ => panic!("expected SlashingProtectionBlocked error"),
+        }
+    }
+
+    #[test]
+    fn test_sign_attestation_different_validators_isolated() {
+        let secret_key1 = SecretKey::generate();
+        let secret_key2 = SecretKey::generate();
+        let pubkey1 = secret_key1.public_key();
+        let pubkey2 = secret_key2.public_key();
+
+        let mut key_manager = KeyManager::new();
+        key_manager.insert(secret_key1);
+        key_manager.insert(secret_key2);
+        let key_manager = Arc::new(key_manager);
+
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().expect("failed to open db"));
+        let service = SignerService::new(key_manager, slashing_db);
+
+        let attestation_data = create_test_attestation_data(100, 101);
+        let fork = create_test_fork();
+        let genesis_root = [0xaa; 32];
+
+        let result1 = service.sign_attestation(&attestation_data, &pubkey1, &fork, genesis_root);
+        assert!(result1.is_ok());
+
+        let result2 = service.sign_attestation(&attestation_data, &pubkey2, &fork, genesis_root);
+        assert!(result2.is_ok());
+    }
+
+    #[test]
+    fn test_signer_error_display() {
+        let err = SignerError::KeyNotFound("abc123".to_string());
+        assert_eq!(err.to_string(), "key not found for pubkey: abc123");
+
+        use crate::slashing::AttestationSlashingViolation;
+        let slashing_err =
+            SlashingError::SlashableAttestation(AttestationSlashingViolation::DoubleVote {
+                target_epoch: 100,
+            });
+        let err = SignerError::SlashingProtectionBlocked(slashing_err);
+        assert!(err.to_string().contains("slashing protection blocked"));
+    }
+
+    #[test]
+    fn test_signer_service_accessors() {
+        let secret_key = SecretKey::generate();
+        let pubkey = secret_key.public_key();
+        let key_manager = Arc::new(create_test_key_manager_with_key(secret_key));
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().expect("failed to open db"));
+
+        let service = SignerService::new(key_manager, slashing_db);
+
+        assert!(!service.key_manager().is_empty());
+        assert_eq!(service.key_manager().len(), 1);
+
+        let keys = service.key_manager().list_public_keys();
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].to_bytes(), pubkey.to_bytes());
+    }
+}


### PR DESCRIPTION
## Summary

- Implement `SignerService` struct that combines `KeyManager` and `SlashingDb` for secure attestation signing
- Add `sign_attestation()` method with EIP-3076 slashing protection checks
- Record attestations in slashing database after successful signing
- Emit metrics for signing duration, success/failure counts, and slashing protection checks

## Changes

### New Files
- `crates/rvc/src/signer/mod.rs` - SignerService implementation with 13 unit tests

### Modified Files
- `crates/rvc/src/lib.rs` - Add signer module
- `crates/rvc/src/crypto/key_manager.rs` - Add test helper method for inserting keys

## Test Plan

- [x] All 329 tests pass (`cargo test -p rvc`)
- [x] No clippy warnings (`cargo clippy --all-targets`)
- [x] Code formatted (`cargo fmt --check`)
- [x] Test successful attestation signing
- [x] Test slashing protection blocks double votes
- [x] Test slashing protection blocks surrounding/surrounded votes
- [x] Test key not found error
- [x] Test attestation recording in slashing DB

Closes #32

🤖 Generated with [Claude Code](https://claude.ai/code)