### PR TITLE
feat(orchestrator): implement DutyOrchestrator for attestation workflow (#34)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,221 @@
+# Implementation Plan: Parallel Development for Issue #9, #10 & #11
+
+## Overview
+
+Two agents work in parallel on feature sections:
+- **Issue #9**: Section 3 - Slashing Protection (EIP-3076)
+- **Issue #10**: Section 4 - Metrics Foundation
+- **Issue #11**: Section 5 - Core Attestation Flow
+
+---
+
+## Phase 1: Foundation Layer ✅
+
+**Status: COMPLETE**
+
+| Agent | Issue | Task | PR | Status |
+|-------|-------|------|-----|--------|
+| A | #23 | SQLite Database Layer | [#76](https://github.com/rootwarp/rvc/pull/76) | ✅ |
+| B | #28 | Metrics HTTP Endpoint | [#77](https://github.com/rootwarp/rvc/pull/77) | ✅ |
+
+---
+
+## Phase 2: Core Functionality ✅
+
+**Status: COMPLETE**
+
+| Agent | Issue | Task | PR | Status |
+|-------|-------|------|-----|--------|
+| A | #24 | Attestation Safety Checks | [#78](https://github.com/rootwarp/rvc/pull/78) | ✅ |
+| B | #29 | Core Metrics Definitions | [#79](https://github.com/rootwarp/rvc/pull/79) | ✅ |
+
+---
+
+## Phase 3: Recording & Timing ✅
+
+**Status: COMPLETE**
+
+| Agent | Issue | Task | PR | Status |
+|-------|-------|------|-----|--------|
+| A | #25 | Attestation Recording | [#80](https://github.com/rootwarp/rvc/pull/80) | ✅ |
+| B | #31 | Slot Timing Service | [#81](https://github.com/rootwarp/rvc/pull/81) | ✅ |
+
+**#25 Delivered:**
+- `record_attestation()` method with idempotent behavior
+- 6 new unit tests
+
+**#31 Delivered:**
+- `SlotClock` trait + `SystemSlotClock` implementation
+- `AttestationTimer` firing at 1/3 slot time
+- `MockSlotClock` for testing
+- Metrics integration
+- 28 new timing tests
+
+---
+
+## Phase 4: Import/Export & Duty Tracker ✅
+
+**Status: COMPLETE**
+
+| Agent | Issue | Task | PR | Status |
+|-------|-------|------|-----|--------|
+| A | #26 | EIP-3076 Import/Export | [#82](https://github.com/rootwarp/rvc/pull/82) | ✅ |
+| B | #30 | Duty Tracker + Beacon | [#83](https://github.com/rootwarp/rvc/pull/83) | ✅ |
+
+**#26 Delivered:**
+- `export()` method for EIP-3076 InterchangeFormat
+- `import()` method with genesis root validation
+- Round-trip compatibility
+- 12 new unit tests
+
+**#30 Delivered:**
+- `DutyTracker` struct with beacon client integration
+- `fetch_duties_for_epoch(epoch)` method
+- `get_duty(slot, committee_index)` cache lookup
+- Dependent root tracking for cache invalidation
+- Metrics: `RVC_DUTY_CACHE_OPERATIONS_TOTAL`, `RVC_DEPENDENT_ROOT_CHANGES_TOTAL`, `RVC_DUTY_FETCH_DURATION_SECONDS`
+- 15 new unit tests
+
+---
+
+## Phase 5: Signer & Propagator Services ✅
+
+**Status: COMPLETE**
+
+| Agent | Issue | Task | PR | Status |
+|-------|-------|------|-----|--------|
+| A | #32 | Signer Service | [#84](https://github.com/rootwarp/rvc/pull/84) | ✅ |
+| B | #33 | Propagator Service | [#85](https://github.com/rootwarp/rvc/pull/85) | ✅ |
+
+**#32 Delivered:**
+- `SignerService` struct combining `KeyManager` and `SlashingDb`
+- `sign_attestation()` method with EIP-3076 slashing protection
+- Records attestation in slashing DB after successful signing
+- Metrics: `RVC_SIGNING_DURATION_SECONDS`, `RVC_SLASHING_PROTECTION_CHECKS_TOTAL`
+- 13 new unit tests
+
+**#33 Delivered:**
+- `Propagator<S>` struct generic over `AttestationSubmitter` trait
+- `propagate()` and `propagate_batch()` methods
+- Leverages BeaconClient's built-in retry logic
+- `PropagationResult` struct with success/failure tracking
+- Metrics: `RVC_ATTESTATIONS_TOTAL` with success/failed labels
+- 18 new unit tests
+
+---
+
+## Phase 6: Duty Orchestrator
+
+**Status: TODO**
+
+| Agent | Issue | Task | Branch | Complexity | Blocked By |
+|-------|-------|------|--------|------------|------------|
+| A+B | #34 | Duty Orchestrator | `feature/34-duty-orchestrator` | L | #30 ✓, #31 ✓, #32 ✓, #33 ✓ |
+
+**#34 Scope:**
+- `DutyOrchestrator` struct coordinating all services
+- Workflow: duty fetch → wait for slot → get attestation data → sign → propagate
+- Handles multiple validators in parallel
+- Graceful handling of missed slots
+- Proper shutdown handling
+
+---
+
+## Phase 7: Main Server Integration
+
+**Status: TODO**
+
+| Agent | Issue | Task | Branch | Complexity | Blocked By |
+|-------|-------|------|--------|------------|------------|
+| A+B | #35 | Main Server Wiring | `feature/35-main-server-wiring` | M | #34 |
+
+**#35 Scope:**
+- Configuration struct for all settings
+- Config file support (TOML)
+- CLI arguments for overrides
+- Service initialization and dependency injection
+- Graceful shutdown on SIGTERM/SIGINT
+
+---
+
+## Summary
+
+### Dependency Graph
+
+```
+Section 3: Slashing Protection (Issue #9) ✅ COMPLETE
+=====================================================
+#22 ✓ → #23 ✓ → #24 ✓
+              → #25 ✓
+              → #26 ✓
+
+Section 4: Metrics Foundation (Issue #10) ✅ COMPLETE
+=====================================================
+#27 ✓ → #28 ✓
+      → #29 ✓
+
+Section 5: Core Attestation Flow (Issue #11)
+============================================
+#30 ✓ ─────────────┐
+#31 ✓ ─────────────┼──> #34 [Phase 6] ──> #35 [Phase 7]
+#32 ✓ ─────────────┤
+#33 ✓ ─────────────┘
+```
+
+### Phase Overview
+
+| Phase | Agent A | Agent B | Status |
+|-------|---------|---------|--------|
+| 1 | #23 SQLite DB | #28 HTTP Endpoint | ✅ |
+| 2 | #24 Safety Checks | #29 Core Metrics | ✅ |
+| 3 | #25 Recording | #31 Slot Timing | ✅ |
+| 4 | #26 Import/Export | #30 Duty Tracker | ✅ |
+| 5 | #32 Signer Service | #33 Propagator | ✅ |
+| 6 | #34 Duty Orchestrator (joint) | | TODO |
+| 7 | #35 Main Server (joint) | | TODO |
+
+### Completed PRs
+
+| PR | Issue | Status |
+|----|-------|--------|
+| [#76](https://github.com/rootwarp/rvc/pull/76) | #23 | ✅ Merged |
+| [#77](https://github.com/rootwarp/rvc/pull/77) | #28 | ✅ Merged |
+| [#78](https://github.com/rootwarp/rvc/pull/78) | #24 | ✅ Merged |
+| [#79](https://github.com/rootwarp/rvc/pull/79) | #29 | ✅ Merged |
+| [#80](https://github.com/rootwarp/rvc/pull/80) | #25 | ✅ Merged |
+| [#81](https://github.com/rootwarp/rvc/pull/81) | #31 | ✅ Merged |
+| [#82](https://github.com/rootwarp/rvc/pull/82) | #26 | ✅ Merged |
+| [#83](https://github.com/rootwarp/rvc/pull/83) | #30 | ✅ Merged |
+| [#84](https://github.com/rootwarp/rvc/pull/84) | #32 | ✅ Merged |
+| [#85](https://github.com/rootwarp/rvc/pull/85) | #33 | ✅ Merged |
+
+---
+
+## Verification Commands
+
+```bash
+# Run all tests
+cargo test --workspace
+
+# Slashing tests
+cargo test -p rvc slashing
+
+# Metrics tests
+cargo test -p rvc metrics
+
+# Timing tests
+cargo test -p rvc timing
+
+# Duty tracker tests
+cargo test -p rvc duty_tracker
+
+# Signer tests
+cargo test -p rvc signer
+
+# Propagator tests
+cargo test -p rvc propagator
+
+# Lint
+cargo clippy --all-targets
+cargo fmt --check
+```

--- a/crates/rvc/src/lib.rs
+++ b/crates/rvc/src/lib.rs
@@ -4,6 +4,7 @@ pub mod beacon;
 pub mod crypto;
 pub mod duty_tracker;
 pub mod metrics;
+pub mod orchestrator;
 pub mod propagator;
 pub mod signer;
 pub mod slashing;

--- a/crates/rvc/src/metrics/definitions.rs
+++ b/crates/rvc/src/metrics/definitions.rs
@@ -5,7 +5,7 @@
 //! and slashing protection.
 
 use lazy_static::lazy_static;
-use prometheus::{HistogramOpts, HistogramVec, IntCounterVec, Opts};
+use prometheus::{Gauge, HistogramOpts, HistogramVec, IntCounterVec, Opts};
 
 use super::REGISTRY;
 
@@ -117,6 +117,58 @@ lazy_static! {
             .expect("Failed to register rvc_slashing_protection_checks_total metric");
         counter
     };
+
+    /// Counter for slots processed by the orchestrator.
+    pub static ref RVC_ORCHESTRATOR_SLOTS_PROCESSED_TOTAL: IntCounterVec = {
+        let opts = Opts::new(
+            "rvc_orchestrator_slots_processed_total",
+            "Total number of slots processed by the orchestrator"
+        );
+        let counter = IntCounterVec::new(opts, &["result"])
+            .expect("Failed to create rvc_orchestrator_slots_processed_total metric");
+        REGISTRY.register(Box::new(counter.clone()))
+            .expect("Failed to register rvc_orchestrator_slots_processed_total metric");
+        counter
+    };
+
+    /// Counter for missed slots.
+    pub static ref RVC_ORCHESTRATOR_MISSED_SLOTS_TOTAL: IntCounterVec = {
+        let opts = Opts::new(
+            "rvc_orchestrator_missed_slots_total",
+            "Total number of missed attestation slots"
+        );
+        let counter = IntCounterVec::new(opts, &[])
+            .expect("Failed to create rvc_orchestrator_missed_slots_total metric");
+        REGISTRY.register(Box::new(counter.clone()))
+            .expect("Failed to register rvc_orchestrator_missed_slots_total metric");
+        counter
+    };
+
+    /// Gauge for currently active attestation tasks.
+    pub static ref RVC_ORCHESTRATOR_ACTIVE_ATTESTATIONS: Gauge = {
+        let opts = Opts::new(
+            "rvc_orchestrator_active_attestations",
+            "Number of currently active attestation tasks"
+        );
+        let gauge = Gauge::with_opts(opts)
+            .expect("Failed to create rvc_orchestrator_active_attestations metric");
+        REGISTRY.register(Box::new(gauge.clone()))
+            .expect("Failed to register rvc_orchestrator_active_attestations metric");
+        gauge
+    };
+
+    /// Histogram for slot processing duration in seconds.
+    pub static ref RVC_ORCHESTRATOR_SLOT_PROCESSING_DURATION_SECONDS: HistogramVec = {
+        let opts = HistogramOpts::new(
+            "rvc_orchestrator_slot_processing_duration_seconds",
+            "Duration of slot processing operations in seconds"
+        ).buckets(vec![0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 12.0]);
+        let histogram = HistogramVec::new(opts, &[])
+            .expect("Failed to create rvc_orchestrator_slot_processing_duration_seconds metric");
+        REGISTRY.register(Box::new(histogram.clone()))
+            .expect("Failed to register rvc_orchestrator_slot_processing_duration_seconds metric");
+        histogram
+    };
 }
 
 /// Initializes all core metrics by accessing the lazy_static variables.
@@ -130,6 +182,10 @@ pub fn init_metrics() {
     lazy_static::initialize(&RVC_SIGNING_DURATION_SECONDS);
     lazy_static::initialize(&RVC_BEACON_REQUESTS_TOTAL);
     lazy_static::initialize(&RVC_SLASHING_PROTECTION_CHECKS_TOTAL);
+    lazy_static::initialize(&RVC_ORCHESTRATOR_SLOTS_PROCESSED_TOTAL);
+    lazy_static::initialize(&RVC_ORCHESTRATOR_MISSED_SLOTS_TOTAL);
+    lazy_static::initialize(&RVC_ORCHESTRATOR_ACTIVE_ATTESTATIONS);
+    lazy_static::initialize(&RVC_ORCHESTRATOR_SLOT_PROCESSING_DURATION_SECONDS);
 }
 
 /// Attestation status label values.
@@ -156,6 +212,13 @@ pub mod cache_operation {
     pub const HIT: &str = "hit";
     pub const MISS: &str = "miss";
     pub const INVALIDATION: &str = "invalidation";
+}
+
+/// Orchestrator slot processing result label values.
+pub mod orchestrator_result {
+    pub const SUCCESS: &str = "success";
+    pub const FAILED: &str = "failed";
+    pub const NO_DUTIES: &str = "no_duties";
 }
 
 #[cfg(test)]

--- a/crates/rvc/src/orchestrator/error.rs
+++ b/crates/rvc/src/orchestrator/error.rs
@@ -1,0 +1,99 @@
+//! Error types for the duty orchestrator.
+
+use thiserror::Error;
+
+use crate::beacon::BeaconError;
+use crate::duty_tracker::DutyTrackerError;
+use crate::propagator::PropagatorError;
+use crate::signer::SignerError;
+use crate::timing::TimingError;
+
+/// Errors that can occur during duty orchestration.
+#[derive(Debug, Error)]
+pub enum OrchestratorError {
+    #[error("Timing error: {0}")]
+    Timing(#[from] TimingError),
+
+    #[error("Duty tracker error: {0}")]
+    DutyTracker(#[from] DutyTrackerError),
+
+    #[error("Signer error: {0}")]
+    Signer(#[from] SignerError),
+
+    #[error("Propagator error: {0}")]
+    Propagator(#[from] PropagatorError),
+
+    #[error("Beacon error: {0}")]
+    Beacon(#[from] BeaconError),
+
+    #[error("Slot {slot} was missed (current slot is {current_slot})")]
+    SlotMissed { slot: u64, current_slot: u64 },
+
+    #[error("Shutdown requested")]
+    Shutdown,
+
+    #[error("No duties found for slot {slot}")]
+    NoDutiesForSlot { slot: u64 },
+
+    #[error("Failed to parse attestation data: {0}")]
+    ParseError(String),
+
+    #[error("Invalid validator pubkey: {0}")]
+    InvalidPubkey(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_orchestrator_error_display_timing() {
+        let timing_err = TimingError::Cancelled;
+        let err = OrchestratorError::Timing(timing_err);
+        assert_eq!(err.to_string(), "Timing error: timer cancelled");
+    }
+
+    #[test]
+    fn test_orchestrator_error_display_slot_missed() {
+        let err = OrchestratorError::SlotMissed { slot: 100, current_slot: 105 };
+        assert_eq!(err.to_string(), "Slot 100 was missed (current slot is 105)");
+    }
+
+    #[test]
+    fn test_orchestrator_error_display_shutdown() {
+        let err = OrchestratorError::Shutdown;
+        assert_eq!(err.to_string(), "Shutdown requested");
+    }
+
+    #[test]
+    fn test_orchestrator_error_display_no_duties() {
+        let err = OrchestratorError::NoDutiesForSlot { slot: 42 };
+        assert_eq!(err.to_string(), "No duties found for slot 42");
+    }
+
+    #[test]
+    fn test_orchestrator_error_display_parse_error() {
+        let err = OrchestratorError::ParseError("invalid format".to_string());
+        assert_eq!(err.to_string(), "Failed to parse attestation data: invalid format");
+    }
+
+    #[test]
+    fn test_orchestrator_error_display_invalid_pubkey() {
+        let err = OrchestratorError::InvalidPubkey("0xabc".to_string());
+        assert_eq!(err.to_string(), "Invalid validator pubkey: 0xabc");
+    }
+
+    #[test]
+    fn test_from_timing_error() {
+        let timing_err = TimingError::BeforeGenesis { current_time: 100, genesis_time: 200 };
+        let err: OrchestratorError = timing_err.into();
+        assert!(matches!(err, OrchestratorError::Timing(_)));
+    }
+
+    #[test]
+    fn test_from_beacon_error() {
+        let beacon_err = BeaconError::Timeout;
+        let err: OrchestratorError = beacon_err.into();
+        assert!(matches!(err, OrchestratorError::Beacon(_)));
+    }
+}

--- a/crates/rvc/src/orchestrator/mod.rs
+++ b/crates/rvc/src/orchestrator/mod.rs
@@ -1,0 +1,10 @@
+//! Duty orchestrator for coordinating the attestation workflow.
+//!
+//! This module provides the [`DutyOrchestrator`] service that coordinates
+//! the full attestation workflow: duty fetch, slot timing, signing, and propagation.
+
+mod error;
+mod service;
+
+pub use error::OrchestratorError;
+pub use service::{DutyOrchestrator, OrchestratorConfig, OrchestratorHandle};

--- a/crates/rvc/src/orchestrator/service.rs
+++ b/crates/rvc/src/orchestrator/service.rs
@@ -10,14 +10,19 @@ use tracing::{debug, error, info, warn};
 use crate::beacon::{Attestation, AttesterDuty, BeaconClient};
 use crate::crypto::{Fork, PublicKey, Root, Slot};
 use crate::duty_tracker::DutyTracker;
-use crate::metrics::definitions::{attestation_status, RVC_ATTESTATIONS_TOTAL};
+use crate::metrics::definitions::{
+    attestation_status, orchestrator_result, RVC_ATTESTATIONS_TOTAL,
+    RVC_ORCHESTRATOR_ACTIVE_ATTESTATIONS, RVC_ORCHESTRATOR_MISSED_SLOTS_TOTAL,
+    RVC_ORCHESTRATOR_SLOTS_PROCESSED_TOTAL, RVC_ORCHESTRATOR_SLOT_PROCESSING_DURATION_SECONDS,
+};
 use crate::propagator::{AttestationSubmitter, Propagator};
 use crate::signer::SignerService;
-use crate::timing::SlotClock;
+use crate::timing::{SlotClock, SLOTS_PER_EPOCH};
 
 use super::error::OrchestratorError;
 
-const SLOTS_PER_EPOCH: u64 = 32;
+/// Default timeout for beacon client API calls in seconds.
+const BEACON_CALL_TIMEOUT_SECS: u64 = 4;
 
 /// Configuration for the duty orchestrator.
 #[derive(Clone)]
@@ -44,7 +49,11 @@ pub struct OrchestratorHandle {
 }
 
 impl OrchestratorHandle {
-    /// Signal the orchestrator to shut down gracefully.
+    /// Signals the orchestrator to shut down gracefully.
+    ///
+    /// The orchestrator will complete processing of the current slot (if any)
+    /// before stopping. The signal is delivered via a watch channel, ensuring
+    /// the orchestrator receives it even if waiting for the next slot.
     pub fn shutdown(&self) {
         let _ = self.shutdown_tx.send(true);
     }
@@ -204,15 +213,23 @@ where
     }
 
     /// Processes all attestation duties for a given slot.
+    ///
+    /// Validators are processed sequentially within each slot to work with
+    /// the non-Send/Sync `SlashingDb`. For high validator counts, consider
+    /// making `SlashingDb` thread-safe with proper locking for concurrent processing.
     pub async fn process_slot(
         &self,
         slot: Slot,
     ) -> Result<Vec<AttestationResult>, OrchestratorError> {
+        let _timer =
+            RVC_ORCHESTRATOR_SLOT_PROCESSING_DURATION_SECONDS.with_label_values(&[]).start_timer();
+
         info!(slot = slot, "Processing attestation duties for slot");
 
         let current_slot = self.clock.current_slot()?;
 
         if current_slot > slot {
+            RVC_ORCHESTRATOR_MISSED_SLOTS_TOTAL.with_label_values(&[]).inc();
             return Err(OrchestratorError::SlotMissed { slot, current_slot });
         }
 
@@ -220,10 +237,14 @@ where
 
         if duties.is_empty() {
             debug!(slot = slot, "No attestation duties for this slot");
+            RVC_ORCHESTRATOR_SLOTS_PROCESSED_TOTAL
+                .with_label_values(&[orchestrator_result::NO_DUTIES])
+                .inc();
             return Err(OrchestratorError::NoDutiesForSlot { slot });
         }
 
         info!(slot = slot, duty_count = duties.len(), "Found attestation duties");
+        RVC_ORCHESTRATOR_ACTIVE_ATTESTATIONS.set(duties.len() as f64);
 
         let mut results = Vec::new();
 
@@ -247,8 +268,20 @@ where
             results.push(result);
         }
 
+        RVC_ORCHESTRATOR_ACTIVE_ATTESTATIONS.set(0.0);
+
         let success_count = results.iter().filter(|r| r.success).count();
         let failure_count = results.len() - success_count;
+
+        if failure_count > 0 {
+            RVC_ORCHESTRATOR_SLOTS_PROCESSED_TOTAL
+                .with_label_values(&[orchestrator_result::FAILED])
+                .inc();
+        } else {
+            RVC_ORCHESTRATOR_SLOTS_PROCESSED_TOTAL
+                .with_label_values(&[orchestrator_result::SUCCESS])
+                .inc();
+        }
 
         info!(
             slot = slot,
@@ -275,15 +308,17 @@ where
             self.duty_tracker.fetch_duties_for_epoch(epoch).await?;
         }
 
+        // Normalize all pubkeys to lowercase without 0x prefix for efficient lookup
+        let normalized_pubkeys: std::collections::HashSet<String> =
+            self.pubkey_map.keys().map(|k| Self::normalize_pubkey(k)).collect();
+
         let mut duties = Vec::new();
-        for pubkey_hex in self.pubkey_map.keys() {
-            for committee_index in 0..64 {
-                if let Ok(duty) = self.duty_tracker.get_duty(slot, committee_index).await {
-                    if duty.pubkey.to_lowercase().contains(&pubkey_hex.to_lowercase()[2..])
-                        || pubkey_hex.to_lowercase().contains(&duty.pubkey.to_lowercase()[2..])
-                    {
-                        duties.push(duty);
-                    }
+        // Check a reasonable range of committee indices (typical max is 64 per slot)
+        for committee_index in 0..64 {
+            if let Ok(duty) = self.duty_tracker.get_duty(slot, committee_index).await {
+                let normalized_duty_pubkey = Self::normalize_pubkey(&duty.pubkey);
+                if normalized_pubkeys.contains(&normalized_duty_pubkey) {
+                    duties.push(duty);
                 }
             }
         }
@@ -291,10 +326,44 @@ where
         Ok(duties)
     }
 
+    /// Normalizes a pubkey to lowercase without 0x/0X prefix for comparison.
+    fn normalize_pubkey(pubkey: &str) -> String {
+        let without_prefix = pubkey
+            .strip_prefix("0x")
+            .or_else(|| pubkey.strip_prefix("0X"))
+            .unwrap_or(pubkey);
+        without_prefix.to_lowercase()
+    }
+
     async fn process_attestation_duty(&self, duty: AttesterDuty) -> AttestationResult {
-        let slot: Slot = duty.slot.parse().unwrap_or(0);
-        let committee_index: u64 = duty.committee_index.parse().unwrap_or(0);
         let validator_index = duty.validator_index.clone();
+
+        let slot: Slot = match duty.slot.parse() {
+            Ok(s) => s,
+            Err(_) => {
+                return AttestationResult {
+                    validator_index,
+                    slot: 0,
+                    success: false,
+                    error: Some(format!("Invalid slot in duty: {}", duty.slot)),
+                };
+            }
+        };
+
+        let committee_index: u64 = match duty.committee_index.parse() {
+            Ok(c) => c,
+            Err(_) => {
+                return AttestationResult {
+                    validator_index,
+                    slot,
+                    success: false,
+                    error: Some(format!(
+                        "Invalid committee_index in duty: {}",
+                        duty.committee_index
+                    )),
+                };
+            }
+        };
 
         debug!(
             validator = %validator_index,
@@ -315,18 +384,32 @@ where
             }
         };
 
-        let attestation_data_response =
-            match self.beacon_client.get_attestation_data(slot, committee_index).await {
-                Ok(response) => response,
-                Err(e) => {
-                    return AttestationResult {
-                        validator_index,
-                        slot,
-                        success: false,
-                        error: Some(format!("Failed to get attestation data: {}", e)),
-                    };
-                }
-            };
+        // Apply timeout to beacon client call to prevent blocking
+        let attestation_data_result = tokio::time::timeout(
+            Duration::from_secs(BEACON_CALL_TIMEOUT_SECS),
+            self.beacon_client.get_attestation_data(slot, committee_index),
+        )
+        .await;
+
+        let attestation_data_response = match attestation_data_result {
+            Ok(Ok(response)) => response,
+            Ok(Err(e)) => {
+                return AttestationResult {
+                    validator_index,
+                    slot,
+                    success: false,
+                    error: Some(format!("Failed to get attestation data: {}", e)),
+                };
+            }
+            Err(_) => {
+                return AttestationResult {
+                    validator_index,
+                    slot,
+                    success: false,
+                    error: Some("Timeout getting attestation data from beacon node".to_string()),
+                };
+            }
+        };
 
         let beacon_attestation_data = attestation_data_response.data;
 
@@ -360,8 +443,35 @@ where
             }
         };
 
-        let committee_length: u64 = duty.committee_length.parse().unwrap_or(128);
-        let validator_committee_index: u64 = duty.validator_committee_index.parse().unwrap_or(0);
+        let committee_length: u64 = match duty.committee_length.parse() {
+            Ok(c) => c,
+            Err(_) => {
+                return AttestationResult {
+                    validator_index,
+                    slot,
+                    success: false,
+                    error: Some(format!(
+                        "Invalid committee_length in duty: {}",
+                        duty.committee_length
+                    )),
+                };
+            }
+        };
+
+        let validator_committee_index: u64 = match duty.validator_committee_index.parse() {
+            Ok(v) => v,
+            Err(_) => {
+                return AttestationResult {
+                    validator_index,
+                    slot,
+                    success: false,
+                    error: Some(format!(
+                        "Invalid validator_committee_index in duty: {}",
+                        duty.validator_committee_index
+                    )),
+                };
+            }
+        };
 
         let aggregation_bits =
             Self::create_aggregation_bits(committee_length, validator_committee_index);
@@ -383,11 +493,16 @@ where
         }
     }
 
+    /// Finds a public key by matching against duty pubkey.
+    ///
+    /// Pubkeys are matched case-insensitively and with/without "0x" prefix.
     fn find_pubkey(&self, duty_pubkey: &str) -> Option<PublicKey> {
+        // Try exact match first
         if let Some(pk) = self.pubkey_map.get(duty_pubkey) {
             return Some(pk.clone());
         }
 
+        // Try with/without 0x prefix
         let normalized_pubkey = if duty_pubkey.starts_with("0x") {
             duty_pubkey.to_string()
         } else {
@@ -398,10 +513,11 @@ where
             return Some(pk.clone());
         }
 
+        // Normalize for case-insensitive matching
+        let duty_normalized = Self::normalize_pubkey(duty_pubkey);
+
         for (key, pk) in &self.pubkey_map {
-            if key.to_lowercase() == duty_pubkey.to_lowercase()
-                || key.to_lowercase() == normalized_pubkey.to_lowercase()
-            {
+            if Self::normalize_pubkey(key) == duty_normalized {
                 return Some(pk.clone());
             }
         }
@@ -467,6 +583,14 @@ where
         Ok(root)
     }
 
+    /// Creates an SSZ-encoded aggregation bitfield with a single bit set.
+    ///
+    /// The bitfield uses little-endian bit ordering within each byte:
+    /// - Validator 0 sets bit 0 of byte 0 (0x01)
+    /// - Validator 7 sets bit 7 of byte 0 (0x80)
+    /// - Validator 8 sets bit 0 of byte 1 (0x0001)
+    ///
+    /// Returns a hex string with "0x" prefix.
     fn create_aggregation_bits(committee_length: u64, validator_index: u64) -> String {
         let byte_length = committee_length.div_ceil(8);
         let mut bits = vec![0u8; byte_length as usize];

--- a/crates/rvc/src/orchestrator/service.rs
+++ b/crates/rvc/src/orchestrator/service.rs
@@ -328,10 +328,8 @@ where
 
     /// Normalizes a pubkey to lowercase without 0x/0X prefix for comparison.
     fn normalize_pubkey(pubkey: &str) -> String {
-        let without_prefix = pubkey
-            .strip_prefix("0x")
-            .or_else(|| pubkey.strip_prefix("0X"))
-            .unwrap_or(pubkey);
+        let without_prefix =
+            pubkey.strip_prefix("0x").or_else(|| pubkey.strip_prefix("0X")).unwrap_or(pubkey);
         without_prefix.to_lowercase()
     }
 

--- a/crates/rvc/src/orchestrator/service.rs
+++ b/crates/rvc/src/orchestrator/service.rs
@@ -1,0 +1,967 @@
+//! Main duty orchestrator implementation.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::watch;
+use tracing::{debug, error, info, warn};
+
+use crate::beacon::{Attestation, AttesterDuty, BeaconClient};
+use crate::crypto::{Fork, PublicKey, Root, Slot};
+use crate::duty_tracker::DutyTracker;
+use crate::metrics::definitions::{attestation_status, RVC_ATTESTATIONS_TOTAL};
+use crate::propagator::{AttestationSubmitter, Propagator};
+use crate::signer::SignerService;
+use crate::timing::SlotClock;
+
+use super::error::OrchestratorError;
+
+const SLOTS_PER_EPOCH: u64 = 32;
+
+/// Configuration for the duty orchestrator.
+#[derive(Clone)]
+pub struct OrchestratorConfig {
+    pub genesis_validators_root: Root,
+    pub fork: Fork,
+    pub shutdown_timeout: Duration,
+}
+
+impl OrchestratorConfig {
+    pub fn new(genesis_validators_root: Root, fork: Fork) -> Self {
+        Self { genesis_validators_root, fork, shutdown_timeout: Duration::from_secs(30) }
+    }
+
+    pub fn with_shutdown_timeout(mut self, timeout: Duration) -> Self {
+        self.shutdown_timeout = timeout;
+        self
+    }
+}
+
+/// Handle for controlling the orchestrator.
+pub struct OrchestratorHandle {
+    shutdown_tx: watch::Sender<bool>,
+}
+
+impl OrchestratorHandle {
+    /// Signal the orchestrator to shut down gracefully.
+    pub fn shutdown(&self) {
+        let _ = self.shutdown_tx.send(true);
+    }
+}
+
+/// Result of processing a single attestation duty.
+#[derive(Debug)]
+pub struct AttestationResult {
+    pub validator_index: String,
+    pub slot: Slot,
+    pub success: bool,
+    pub error: Option<String>,
+}
+
+/// Main orchestrator for coordinating attestation duties.
+pub struct DutyOrchestrator<C, S>
+where
+    C: SlotClock + 'static,
+    S: AttestationSubmitter + 'static,
+{
+    clock: Arc<C>,
+    duty_tracker: Arc<DutyTracker>,
+    signer: Arc<SignerService>,
+    propagator: Arc<Propagator<S>>,
+    beacon_client: Arc<BeaconClient>,
+    config: OrchestratorConfig,
+    pubkey_map: HashMap<String, PublicKey>,
+    shutdown_rx: watch::Receiver<bool>,
+}
+
+impl<C, S> DutyOrchestrator<C, S>
+where
+    C: SlotClock + 'static,
+    S: AttestationSubmitter + 'static,
+{
+    /// Creates a new DutyOrchestrator with the given dependencies.
+    pub fn new(
+        clock: Arc<C>,
+        duty_tracker: Arc<DutyTracker>,
+        signer: Arc<SignerService>,
+        propagator: Arc<Propagator<S>>,
+        beacon_client: Arc<BeaconClient>,
+        config: OrchestratorConfig,
+        pubkey_map: HashMap<String, PublicKey>,
+    ) -> (Self, OrchestratorHandle) {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let orchestrator = Self {
+            clock,
+            duty_tracker,
+            signer,
+            propagator,
+            beacon_client,
+            config,
+            pubkey_map,
+            shutdown_rx,
+        };
+
+        let handle = OrchestratorHandle { shutdown_tx };
+
+        (orchestrator, handle)
+    }
+
+    /// Runs the orchestrator main loop.
+    pub async fn run(&mut self) -> Result<(), OrchestratorError> {
+        info!("Starting duty orchestrator");
+
+        loop {
+            if *self.shutdown_rx.borrow() {
+                info!("Shutdown signal received, stopping orchestrator");
+                return Ok(());
+            }
+
+            let current_slot = match self.clock.current_slot() {
+                Ok(slot) => slot,
+                Err(e) => {
+                    warn!(error = %e, "Failed to get current slot, waiting...");
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    continue;
+                }
+            };
+
+            let current_epoch = current_slot / SLOTS_PER_EPOCH;
+
+            if !self.duty_tracker.is_epoch_cached(current_epoch).await {
+                debug!(epoch = current_epoch, "Fetching duties for current epoch");
+                if let Err(e) = self.duty_tracker.fetch_duties_for_epoch(current_epoch).await {
+                    warn!(epoch = current_epoch, error = %e, "Failed to fetch duties for epoch");
+                }
+            }
+
+            let next_epoch = current_epoch + 1;
+            if !self.duty_tracker.is_epoch_cached(next_epoch).await {
+                debug!(epoch = next_epoch, "Prefetching duties for next epoch");
+                if let Err(e) = self.duty_tracker.fetch_duties_for_epoch(next_epoch).await {
+                    warn!(epoch = next_epoch, error = %e, "Failed to prefetch duties for next epoch");
+                }
+            }
+
+            let time_until_attestation = self.clock.time_until_attestation(current_slot)?;
+
+            if !time_until_attestation.is_zero() {
+                debug!(
+                    slot = current_slot,
+                    wait_ms = time_until_attestation.as_millis(),
+                    "Waiting for attestation time"
+                );
+
+                tokio::select! {
+                    _ = tokio::time::sleep(time_until_attestation) => {}
+                    _ = self.shutdown_rx.changed() => {
+                        if *self.shutdown_rx.borrow() {
+                            info!("Shutdown signal received during wait");
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+
+            if *self.shutdown_rx.borrow() {
+                info!("Shutdown signal received, stopping orchestrator");
+                return Ok(());
+            }
+
+            if let Err(e) = self.process_slot(current_slot).await {
+                match &e {
+                    OrchestratorError::SlotMissed { slot, current_slot } => {
+                        warn!(slot = slot, current_slot = current_slot, "Missed slot");
+                        RVC_ATTESTATIONS_TOTAL
+                            .with_label_values(&[attestation_status::SKIPPED])
+                            .inc();
+                    }
+                    OrchestratorError::NoDutiesForSlot { slot } => {
+                        debug!(slot = slot, "No duties for slot");
+                    }
+                    _ => {
+                        error!(slot = current_slot, error = %e, "Error processing slot");
+                    }
+                }
+            }
+
+            let next_slot = current_slot + 1;
+            let time_until_next_slot = self.clock.time_until_slot(next_slot)?;
+
+            if !time_until_next_slot.is_zero() {
+                tokio::select! {
+                    _ = tokio::time::sleep(time_until_next_slot) => {}
+                    _ = self.shutdown_rx.changed() => {
+                        if *self.shutdown_rx.borrow() {
+                            info!("Shutdown signal received waiting for next slot");
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Processes all attestation duties for a given slot.
+    pub async fn process_slot(
+        &self,
+        slot: Slot,
+    ) -> Result<Vec<AttestationResult>, OrchestratorError> {
+        info!(slot = slot, "Processing attestation duties for slot");
+
+        let current_slot = self.clock.current_slot()?;
+
+        if current_slot > slot {
+            return Err(OrchestratorError::SlotMissed { slot, current_slot });
+        }
+
+        let duties = self.get_duties_for_slot(slot).await?;
+
+        if duties.is_empty() {
+            debug!(slot = slot, "No attestation duties for this slot");
+            return Err(OrchestratorError::NoDutiesForSlot { slot });
+        }
+
+        info!(slot = slot, duty_count = duties.len(), "Found attestation duties");
+
+        let mut results = Vec::new();
+
+        for duty in duties {
+            let result = self.process_attestation_duty(duty).await;
+
+            if result.success {
+                info!(
+                    validator = %result.validator_index,
+                    slot = result.slot,
+                    "Attestation completed successfully"
+                );
+            } else {
+                warn!(
+                    validator = %result.validator_index,
+                    slot = result.slot,
+                    error = ?result.error,
+                    "Attestation failed"
+                );
+            }
+            results.push(result);
+        }
+
+        let success_count = results.iter().filter(|r| r.success).count();
+        let failure_count = results.len() - success_count;
+
+        info!(
+            slot = slot,
+            total = results.len(),
+            success = success_count,
+            failed = failure_count,
+            "Slot processing complete"
+        );
+
+        Ok(results)
+    }
+
+    async fn get_duties_for_slot(
+        &self,
+        slot: Slot,
+    ) -> Result<Vec<AttesterDuty>, OrchestratorError> {
+        if self.pubkey_map.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let epoch = slot / SLOTS_PER_EPOCH;
+
+        if !self.duty_tracker.is_epoch_cached(epoch).await {
+            self.duty_tracker.fetch_duties_for_epoch(epoch).await?;
+        }
+
+        let mut duties = Vec::new();
+        for pubkey_hex in self.pubkey_map.keys() {
+            for committee_index in 0..64 {
+                if let Ok(duty) = self.duty_tracker.get_duty(slot, committee_index).await {
+                    if duty.pubkey.to_lowercase().contains(&pubkey_hex.to_lowercase()[2..])
+                        || pubkey_hex.to_lowercase().contains(&duty.pubkey.to_lowercase()[2..])
+                    {
+                        duties.push(duty);
+                    }
+                }
+            }
+        }
+
+        Ok(duties)
+    }
+
+    async fn process_attestation_duty(&self, duty: AttesterDuty) -> AttestationResult {
+        let slot: Slot = duty.slot.parse().unwrap_or(0);
+        let committee_index: u64 = duty.committee_index.parse().unwrap_or(0);
+        let validator_index = duty.validator_index.clone();
+
+        debug!(
+            validator = %validator_index,
+            slot = slot,
+            committee_index = committee_index,
+            "Processing attestation duty"
+        );
+
+        let pubkey = match self.find_pubkey(&duty.pubkey) {
+            Some(pk) => pk,
+            None => {
+                return AttestationResult {
+                    validator_index,
+                    slot,
+                    success: false,
+                    error: Some(format!("Public key not found: {}", duty.pubkey)),
+                };
+            }
+        };
+
+        let attestation_data_response =
+            match self.beacon_client.get_attestation_data(slot, committee_index).await {
+                Ok(response) => response,
+                Err(e) => {
+                    return AttestationResult {
+                        validator_index,
+                        slot,
+                        success: false,
+                        error: Some(format!("Failed to get attestation data: {}", e)),
+                    };
+                }
+            };
+
+        let beacon_attestation_data = attestation_data_response.data;
+
+        let crypto_attestation_data = match Self::convert_attestation_data(&beacon_attestation_data)
+        {
+            Ok(data) => data,
+            Err(e) => {
+                return AttestationResult {
+                    validator_index,
+                    slot,
+                    success: false,
+                    error: Some(format!("Failed to convert attestation data: {}", e)),
+                };
+            }
+        };
+
+        let signature = match self.signer.sign_attestation(
+            &crypto_attestation_data,
+            &pubkey,
+            &self.config.fork,
+            self.config.genesis_validators_root,
+        ) {
+            Ok(sig) => sig,
+            Err(e) => {
+                return AttestationResult {
+                    validator_index,
+                    slot,
+                    success: false,
+                    error: Some(format!("Failed to sign attestation: {}", e)),
+                };
+            }
+        };
+
+        let committee_length: u64 = duty.committee_length.parse().unwrap_or(128);
+        let validator_committee_index: u64 = duty.validator_committee_index.parse().unwrap_or(0);
+
+        let aggregation_bits =
+            Self::create_aggregation_bits(committee_length, validator_committee_index);
+
+        let attestation = Attestation {
+            aggregation_bits,
+            data: beacon_attestation_data,
+            signature: format!("0x{}", hex::encode(signature.to_bytes())),
+        };
+
+        match self.propagator.propagate(attestation).await {
+            Ok(()) => AttestationResult { validator_index, slot, success: true, error: None },
+            Err(e) => AttestationResult {
+                validator_index,
+                slot,
+                success: false,
+                error: Some(format!("Failed to propagate attestation: {}", e)),
+            },
+        }
+    }
+
+    fn find_pubkey(&self, duty_pubkey: &str) -> Option<PublicKey> {
+        if let Some(pk) = self.pubkey_map.get(duty_pubkey) {
+            return Some(pk.clone());
+        }
+
+        let normalized_pubkey = if duty_pubkey.starts_with("0x") {
+            duty_pubkey.to_string()
+        } else {
+            format!("0x{}", duty_pubkey)
+        };
+
+        if let Some(pk) = self.pubkey_map.get(&normalized_pubkey) {
+            return Some(pk.clone());
+        }
+
+        for (key, pk) in &self.pubkey_map {
+            if key.to_lowercase() == duty_pubkey.to_lowercase()
+                || key.to_lowercase() == normalized_pubkey.to_lowercase()
+            {
+                return Some(pk.clone());
+            }
+        }
+
+        None
+    }
+
+    fn convert_attestation_data(
+        beacon_data: &crate::beacon::AttestationData,
+    ) -> Result<crate::crypto::AttestationData, OrchestratorError> {
+        let slot: u64 = beacon_data
+            .slot
+            .parse()
+            .map_err(|_| OrchestratorError::ParseError("Invalid slot".to_string()))?;
+
+        let index: u64 = beacon_data
+            .index
+            .parse()
+            .map_err(|_| OrchestratorError::ParseError("Invalid index".to_string()))?;
+
+        let beacon_block_root = Self::parse_hex_root(&beacon_data.beacon_block_root)?;
+
+        let source_epoch: u64 = beacon_data
+            .source
+            .epoch
+            .parse()
+            .map_err(|_| OrchestratorError::ParseError("Invalid source epoch".to_string()))?;
+
+        let source_root = Self::parse_hex_root(&beacon_data.source.root)?;
+
+        let target_epoch: u64 = beacon_data
+            .target
+            .epoch
+            .parse()
+            .map_err(|_| OrchestratorError::ParseError("Invalid target epoch".to_string()))?;
+
+        let target_root = Self::parse_hex_root(&beacon_data.target.root)?;
+
+        Ok(crate::crypto::AttestationData {
+            slot,
+            index,
+            beacon_block_root,
+            source: crate::crypto::Checkpoint { epoch: source_epoch, root: source_root },
+            target: crate::crypto::Checkpoint { epoch: target_epoch, root: target_root },
+        })
+    }
+
+    fn parse_hex_root(hex_str: &str) -> Result<Root, OrchestratorError> {
+        let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+
+        let bytes = hex::decode(hex_str)
+            .map_err(|e| OrchestratorError::ParseError(format!("Invalid hex: {}", e)))?;
+
+        if bytes.len() != 32 {
+            return Err(OrchestratorError::ParseError(format!(
+                "Invalid root length: expected 32, got {}",
+                bytes.len()
+            )));
+        }
+
+        let mut root = [0u8; 32];
+        root.copy_from_slice(&bytes);
+        Ok(root)
+    }
+
+    fn create_aggregation_bits(committee_length: u64, validator_index: u64) -> String {
+        let byte_length = committee_length.div_ceil(8);
+        let mut bits = vec![0u8; byte_length as usize];
+
+        if validator_index < committee_length {
+            let byte_index = (validator_index / 8) as usize;
+            let bit_index = validator_index % 8;
+            if byte_index < bits.len() {
+                bits[byte_index] |= 1 << bit_index;
+            }
+        }
+
+        format!("0x{}", hex::encode(bits))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::beacon::BeaconClientConfig;
+    use crate::crypto::{KeyManager, SecretKey};
+    use crate::slashing::SlashingDb;
+    use crate::timing::MockSlotClock;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    const TEST_GENESIS_TIME: u64 = 1606824023;
+
+    fn create_test_fork() -> Fork {
+        Fork {
+            previous_version: [0x00, 0x00, 0x00, 0x01],
+            current_version: [0x00, 0x00, 0x00, 0x02],
+            epoch: 0,
+        }
+    }
+
+    fn create_test_config() -> OrchestratorConfig {
+        OrchestratorConfig::new([0xaa; 32], create_test_fork())
+    }
+
+    struct MockSubmitter {
+        call_count: AtomicUsize,
+        should_succeed: std::sync::atomic::AtomicBool,
+    }
+
+    impl MockSubmitter {
+        fn new() -> Self {
+            Self {
+                call_count: AtomicUsize::new(0),
+                should_succeed: std::sync::atomic::AtomicBool::new(true),
+            }
+        }
+
+        #[allow(dead_code)]
+        fn set_should_succeed(&self, value: bool) {
+            self.should_succeed.store(value, Ordering::SeqCst);
+        }
+
+        #[allow(dead_code)]
+        fn call_count(&self) -> usize {
+            self.call_count.load(Ordering::SeqCst)
+        }
+    }
+
+    impl AttestationSubmitter for MockSubmitter {
+        fn submit_attestation<'a>(
+            &'a self,
+            _attestations: &'a [Attestation],
+        ) -> Pin<
+            Box<
+                dyn Future<
+                        Output = Result<
+                            crate::beacon::SubmitAttestationResult,
+                            crate::beacon::BeaconError,
+                        >,
+                    > + Send
+                    + 'a,
+            >,
+        > {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            let should_succeed = self.should_succeed.load(Ordering::SeqCst);
+            Box::pin(async move {
+                if should_succeed {
+                    Ok(crate::beacon::SubmitAttestationResult::Success)
+                } else {
+                    Err(crate::beacon::BeaconError::Timeout)
+                }
+            })
+        }
+    }
+
+    #[test]
+    fn test_orchestrator_config_new() {
+        let config = OrchestratorConfig::new([0xbb; 32], create_test_fork());
+        assert_eq!(config.genesis_validators_root, [0xbb; 32]);
+        assert_eq!(config.shutdown_timeout, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_orchestrator_config_with_shutdown_timeout() {
+        let config = OrchestratorConfig::new([0xcc; 32], create_test_fork())
+            .with_shutdown_timeout(Duration::from_secs(60));
+        assert_eq!(config.shutdown_timeout, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_create_aggregation_bits_first_validator() {
+        let bits =
+            DutyOrchestrator::<MockSlotClock, MockSubmitter>::create_aggregation_bits(128, 0);
+        assert_eq!(bits, "0x01000000000000000000000000000000");
+    }
+
+    #[test]
+    fn test_create_aggregation_bits_eighth_validator() {
+        let bits =
+            DutyOrchestrator::<MockSlotClock, MockSubmitter>::create_aggregation_bits(128, 7);
+        assert_eq!(bits, "0x80000000000000000000000000000000");
+    }
+
+    #[test]
+    fn test_create_aggregation_bits_ninth_validator() {
+        let bits =
+            DutyOrchestrator::<MockSlotClock, MockSubmitter>::create_aggregation_bits(128, 8);
+        assert_eq!(bits, "0x00010000000000000000000000000000");
+    }
+
+    #[test]
+    fn test_parse_hex_root_with_prefix() {
+        let root = DutyOrchestrator::<MockSlotClock, MockSubmitter>::parse_hex_root(
+            "0x1111111111111111111111111111111111111111111111111111111111111111",
+        )
+        .unwrap();
+        assert_eq!(root, [0x11; 32]);
+    }
+
+    #[test]
+    fn test_parse_hex_root_without_prefix() {
+        let root = DutyOrchestrator::<MockSlotClock, MockSubmitter>::parse_hex_root(
+            "2222222222222222222222222222222222222222222222222222222222222222",
+        )
+        .unwrap();
+        assert_eq!(root, [0x22; 32]);
+    }
+
+    #[test]
+    fn test_parse_hex_root_invalid_length() {
+        let result =
+            DutyOrchestrator::<MockSlotClock, MockSubmitter>::parse_hex_root("0x1111111111");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_hex_root_invalid_hex() {
+        let result = DutyOrchestrator::<MockSlotClock, MockSubmitter>::parse_hex_root("0xgggggggg");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_convert_attestation_data_success() {
+        let beacon_data = crate::beacon::AttestationData {
+            slot: "1000".to_string(),
+            index: "5".to_string(),
+            beacon_block_root: "0x1111111111111111111111111111111111111111111111111111111111111111"
+                .to_string(),
+            source: crate::beacon::Checkpoint {
+                epoch: "100".to_string(),
+                root: "0x2222222222222222222222222222222222222222222222222222222222222222"
+                    .to_string(),
+            },
+            target: crate::beacon::Checkpoint {
+                epoch: "101".to_string(),
+                root: "0x3333333333333333333333333333333333333333333333333333333333333333"
+                    .to_string(),
+            },
+        };
+
+        let crypto_data =
+            DutyOrchestrator::<MockSlotClock, MockSubmitter>::convert_attestation_data(
+                &beacon_data,
+            )
+            .unwrap();
+
+        assert_eq!(crypto_data.slot, 1000);
+        assert_eq!(crypto_data.index, 5);
+        assert_eq!(crypto_data.beacon_block_root, [0x11; 32]);
+        assert_eq!(crypto_data.source.epoch, 100);
+        assert_eq!(crypto_data.source.root, [0x22; 32]);
+        assert_eq!(crypto_data.target.epoch, 101);
+        assert_eq!(crypto_data.target.root, [0x33; 32]);
+    }
+
+    #[test]
+    fn test_convert_attestation_data_invalid_slot() {
+        let beacon_data = crate::beacon::AttestationData {
+            slot: "invalid".to_string(),
+            index: "5".to_string(),
+            beacon_block_root: "0x1111111111111111111111111111111111111111111111111111111111111111"
+                .to_string(),
+            source: crate::beacon::Checkpoint {
+                epoch: "100".to_string(),
+                root: "0x2222222222222222222222222222222222222222222222222222222222222222"
+                    .to_string(),
+            },
+            target: crate::beacon::Checkpoint {
+                epoch: "101".to_string(),
+                root: "0x3333333333333333333333333333333333333333333333333333333333333333"
+                    .to_string(),
+            },
+        };
+
+        let result = DutyOrchestrator::<MockSlotClock, MockSubmitter>::convert_attestation_data(
+            &beacon_data,
+        );
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_orchestrator_handle_shutdown() {
+        let clock = Arc::new(MockSlotClock::new(TEST_GENESIS_TIME, Duration::from_secs(12), 32));
+        clock.set_slot(100);
+
+        let beacon_config = BeaconClientConfig::new("http://localhost:5052");
+        let beacon_client = Arc::new(BeaconClient::new(beacon_config).unwrap());
+
+        let duty_tracker =
+            Arc::new(DutyTracker::new(beacon_client.clone(), vec!["1234".to_string()]));
+
+        let key_manager = Arc::new(KeyManager::new());
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().unwrap());
+        let signer = Arc::new(SignerService::new(key_manager, slashing_db));
+
+        let submitter = Arc::new(MockSubmitter::new());
+        let propagator = Arc::new(Propagator::new(submitter));
+
+        let config = create_test_config();
+        let pubkey_map = HashMap::new();
+
+        let (mut orchestrator, handle) = DutyOrchestrator::new(
+            clock,
+            duty_tracker,
+            signer,
+            propagator,
+            beacon_client,
+            config,
+            pubkey_map,
+        );
+
+        handle.shutdown();
+
+        let result = orchestrator.run().await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_orchestrator_no_duties_for_slot() {
+        let clock = Arc::new(MockSlotClock::new(TEST_GENESIS_TIME, Duration::from_secs(12), 32));
+        clock.set_slot(100);
+
+        let beacon_config = BeaconClientConfig::new("http://localhost:5052");
+        let beacon_client = Arc::new(BeaconClient::new(beacon_config).unwrap());
+
+        let duty_tracker = Arc::new(DutyTracker::new(beacon_client.clone(), vec![]));
+
+        let key_manager = Arc::new(KeyManager::new());
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().unwrap());
+        let signer = Arc::new(SignerService::new(key_manager, slashing_db));
+
+        let submitter = Arc::new(MockSubmitter::new());
+        let propagator = Arc::new(Propagator::new(submitter));
+
+        let config = create_test_config();
+        let pubkey_map = HashMap::new();
+
+        let (orchestrator, _handle) = DutyOrchestrator::new(
+            clock,
+            duty_tracker,
+            signer,
+            propagator,
+            beacon_client,
+            config,
+            pubkey_map,
+        );
+
+        let result = orchestrator.process_slot(100).await;
+
+        assert!(matches!(result, Err(OrchestratorError::NoDutiesForSlot { slot: 100 })));
+    }
+
+    #[tokio::test]
+    async fn test_orchestrator_slot_missed() {
+        let clock = Arc::new(MockSlotClock::new(TEST_GENESIS_TIME, Duration::from_secs(12), 32));
+        clock.set_slot(105);
+
+        let beacon_config = BeaconClientConfig::new("http://localhost:5052");
+        let beacon_client = Arc::new(BeaconClient::new(beacon_config).unwrap());
+
+        let duty_tracker =
+            Arc::new(DutyTracker::new(beacon_client.clone(), vec!["1234".to_string()]));
+
+        let key_manager = Arc::new(KeyManager::new());
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().unwrap());
+        let signer = Arc::new(SignerService::new(key_manager, slashing_db));
+
+        let submitter = Arc::new(MockSubmitter::new());
+        let propagator = Arc::new(Propagator::new(submitter));
+
+        let config = create_test_config();
+        let pubkey_map = HashMap::new();
+
+        let (orchestrator, _handle) = DutyOrchestrator::new(
+            clock,
+            duty_tracker,
+            signer,
+            propagator,
+            beacon_client,
+            config,
+            pubkey_map,
+        );
+
+        let result = orchestrator.process_slot(100).await;
+
+        assert!(matches!(result, Err(OrchestratorError::SlotMissed { .. })));
+    }
+
+    #[test]
+    fn test_attestation_result_success() {
+        let result = AttestationResult {
+            validator_index: "1234".to_string(),
+            slot: 100,
+            success: true,
+            error: None,
+        };
+        assert!(result.success);
+        assert!(result.error.is_none());
+    }
+
+    #[test]
+    fn test_attestation_result_failure() {
+        let result = AttestationResult {
+            validator_index: "1234".to_string(),
+            slot: 100,
+            success: false,
+            error: Some("Test error".to_string()),
+        };
+        assert!(!result.success);
+        assert_eq!(result.error.as_deref(), Some("Test error"));
+    }
+
+    #[tokio::test]
+    async fn test_orchestrator_with_validator_keys() {
+        let clock = Arc::new(MockSlotClock::new(TEST_GENESIS_TIME, Duration::from_secs(12), 32));
+        clock.set_slot(100);
+
+        let beacon_config = BeaconClientConfig::new("http://localhost:5052");
+        let beacon_client = Arc::new(BeaconClient::new(beacon_config).unwrap());
+
+        let secret_key = SecretKey::generate();
+        let pubkey = secret_key.public_key();
+        let pubkey_hex = format!("0x{}", hex::encode(pubkey.to_bytes()));
+
+        let duty_tracker =
+            Arc::new(DutyTracker::new(beacon_client.clone(), vec!["1234".to_string()]));
+
+        let mut key_manager = KeyManager::new();
+        key_manager.insert(secret_key);
+        let key_manager = Arc::new(key_manager);
+
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().unwrap());
+        let signer = Arc::new(SignerService::new(key_manager, slashing_db));
+
+        let submitter = Arc::new(MockSubmitter::new());
+        let propagator = Arc::new(Propagator::new(submitter));
+
+        let config = create_test_config();
+        let mut pubkey_map = HashMap::new();
+        pubkey_map.insert(pubkey_hex, pubkey);
+
+        let (_orchestrator, handle) = DutyOrchestrator::new(
+            clock,
+            duty_tracker,
+            signer,
+            propagator,
+            beacon_client,
+            config,
+            pubkey_map,
+        );
+
+        assert!(!*handle.shutdown_tx.borrow());
+        handle.shutdown();
+        assert!(*handle.shutdown_tx.borrow());
+    }
+
+    #[tokio::test]
+    async fn test_find_pubkey_exact_match() {
+        let clock = Arc::new(MockSlotClock::new(TEST_GENESIS_TIME, Duration::from_secs(12), 32));
+        let beacon_config = BeaconClientConfig::new("http://localhost:5052");
+        let beacon_client = Arc::new(BeaconClient::new(beacon_config).unwrap());
+        let duty_tracker = Arc::new(DutyTracker::new(beacon_client.clone(), vec![]));
+
+        let key_manager = Arc::new(KeyManager::new());
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().unwrap());
+        let signer = Arc::new(SignerService::new(key_manager, slashing_db));
+
+        let submitter = Arc::new(MockSubmitter::new());
+        let propagator = Arc::new(Propagator::new(submitter));
+
+        let secret_key = SecretKey::generate();
+        let pubkey = secret_key.public_key();
+        let pubkey_hex = format!("0x{}", hex::encode(pubkey.to_bytes()));
+
+        let config = create_test_config();
+        let mut pubkey_map = HashMap::new();
+        pubkey_map.insert(pubkey_hex.clone(), pubkey.clone());
+
+        let (orchestrator, _handle) = DutyOrchestrator::new(
+            clock,
+            duty_tracker,
+            signer,
+            propagator,
+            beacon_client,
+            config,
+            pubkey_map,
+        );
+
+        let found = orchestrator.find_pubkey(&pubkey_hex);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().to_bytes(), pubkey.to_bytes());
+    }
+
+    #[tokio::test]
+    async fn test_find_pubkey_case_insensitive() {
+        let clock = Arc::new(MockSlotClock::new(TEST_GENESIS_TIME, Duration::from_secs(12), 32));
+        let beacon_config = BeaconClientConfig::new("http://localhost:5052");
+        let beacon_client = Arc::new(BeaconClient::new(beacon_config).unwrap());
+        let duty_tracker = Arc::new(DutyTracker::new(beacon_client.clone(), vec![]));
+
+        let key_manager = Arc::new(KeyManager::new());
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().unwrap());
+        let signer = Arc::new(SignerService::new(key_manager, slashing_db));
+
+        let submitter = Arc::new(MockSubmitter::new());
+        let propagator = Arc::new(Propagator::new(submitter));
+
+        let secret_key = SecretKey::generate();
+        let pubkey = secret_key.public_key();
+        let pubkey_hex = format!("0x{}", hex::encode(pubkey.to_bytes()));
+
+        let config = create_test_config();
+        let mut pubkey_map = HashMap::new();
+        pubkey_map.insert(pubkey_hex.to_uppercase(), pubkey.clone());
+
+        let (orchestrator, _handle) = DutyOrchestrator::new(
+            clock,
+            duty_tracker,
+            signer,
+            propagator,
+            beacon_client,
+            config,
+            pubkey_map,
+        );
+
+        let found = orchestrator.find_pubkey(&pubkey_hex.to_lowercase());
+        assert!(found.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_find_pubkey_not_found() {
+        let clock = Arc::new(MockSlotClock::new(TEST_GENESIS_TIME, Duration::from_secs(12), 32));
+        let beacon_config = BeaconClientConfig::new("http://localhost:5052");
+        let beacon_client = Arc::new(BeaconClient::new(beacon_config).unwrap());
+        let duty_tracker = Arc::new(DutyTracker::new(beacon_client.clone(), vec![]));
+
+        let key_manager = Arc::new(KeyManager::new());
+        let slashing_db = Arc::new(SlashingDb::open_in_memory().unwrap());
+        let signer = Arc::new(SignerService::new(key_manager, slashing_db));
+
+        let submitter = Arc::new(MockSubmitter::new());
+        let propagator = Arc::new(Propagator::new(submitter));
+
+        let config = create_test_config();
+        let pubkey_map = HashMap::new();
+
+        let (orchestrator, _handle) = DutyOrchestrator::new(
+            clock,
+            duty_tracker,
+            signer,
+            propagator,
+            beacon_client,
+            config,
+            pubkey_map,
+        );
+
+        let found = orchestrator.find_pubkey("0x1234567890abcdef");
+        assert!(found.is_none());
+    }
+}

--- a/crates/rvc/src/orchestrator/service.rs
+++ b/crates/rvc/src/orchestrator/service.rs
@@ -606,6 +606,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::arc_with_non_send_sync)]
 mod tests {
     use super::*;
     use crate::beacon::BeaconClientConfig;


### PR DESCRIPTION
## Summary

Implement the `DutyOrchestrator` service that coordinates the complete attestation workflow for the Rust Validator Client.

- **DutyOrchestrator struct** coordinating all services (DutyTracker, SlotClock, SignerService, Propagator, BeaconClient)
- **Complete workflow**: duty fetch → wait for slot → get attestation data → sign → propagate
- **Sequential validator processing** within each slot to avoid `Send`/`Sync` issues with SlashingDb
- **Graceful handling of missed slots** with appropriate metrics and logging
- **Proper shutdown handling** via `OrchestratorHandle` with watch channel pattern
- **Comprehensive logging** at each workflow step using tracing
- **New orchestrator metrics**: `rvc_orchestrator_slots_processed_total`, `rvc_orchestrator_missed_slots_total`, `rvc_orchestrator_active_attestations`, `rvc_orchestrator_slot_processing_duration_seconds`
- **28 unit tests** covering error handling, configuration, helper functions, and integration

### Files Changed
- `crates/rvc/src/orchestrator/mod.rs` - Module exports
- `crates/rvc/src/orchestrator/error.rs` - OrchestratorError enum with comprehensive error variants
- `crates/rvc/src/orchestrator/service.rs` - Main DutyOrchestrator implementation
- `crates/rvc/src/lib.rs` - Export orchestrator module
- `crates/rvc/src/metrics/definitions.rs` - Add orchestrator-specific metrics

### Architecture

```
DutyOrchestrator (main loop)
    |
    v
DutyTracker.is_epoch_cached() / fetch_duties_for_epoch()
    |
    v
SlotClock.time_until_attestation() -> wait
    |
    v
For each validator duty:
    BeaconClient.get_attestation_data()
    SignerService.sign_attestation()
    Propagator.propagate()
```

Closes #34

## Test plan
- [x] All 357 tests pass (`cargo test --package rvc`)
- [x] No clippy warnings (`cargo clippy --package rvc -- -D warnings`)
- [x] Code formatted (`cargo fmt --check`)
- [x] Error types have correct Display implementations
- [x] Shutdown signal properly stops the orchestrator
- [x] Missed slot detection works correctly
- [x] Public key lookup handles case-insensitive matching

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)